### PR TITLE
Issue #48 fix

### DIFF
--- a/simms/parser_config/skysim.py
+++ b/simms/parser_config/skysim.py
@@ -43,7 +43,7 @@ def runit(**kwargs):
         map_path = f"{thisdir}/library/{opts.cat_species}.yaml"
     else:
         map_path = f"{thisdir}/library/catalogue_template.yaml"
-        print(f"Warning: No mapping file specified nor built-in map selected. Using default mapping file ({map_path})")
+        print(f"Warning: No mapping file specified nor built-in map selected. Assuming default column names (see {map_path})")
 
     mapdata = OmegaConf.load(map_path)
     mapcols = OmegaConf.create({})

--- a/simms/parser_config/skysim.py
+++ b/simms/parser_config/skysim.py
@@ -42,8 +42,8 @@ def runit(**kwargs):
     elif opts.cat_species:
         map_path = f"{thisdir}/library/{opts.cat_species}.yaml"
     else:
-        print("Warning: No mapping file specified nor built-in map selected. Using default catalogue template")
         map_path = f"{thisdir}/library/catalogue_template.yaml"
+        print(f"Warning: No mapping file specified nor built-in map selected. Using default mapping file ({map_path})")
 
     mapdata = OmegaConf.load(map_path)
     mapcols = OmegaConf.create({})
@@ -87,11 +87,15 @@ def runit(**kwargs):
                 mapcols[key][1].append(value)
     
     # validate mapcols to ensure that the required columns were read successfully
-    required_cols = ["name", "ra", "dec", "stokes_i"]
-    for col in required_cols:
+    for col in ["name", "ra", "dec", "stokes_i"]:
         if not mapcols[col][1]: # if the list storing column's data is empty
+            if col == "name": # user might not understand what simply "name" means
+                raise CatalogueError(
+                    f"Failed to identify required column corresponding to source name/ID in the catalogue."
+                    " Please ensure that catalogue column headers match those in mapping file."
+                )
             raise CatalogueError(
-                f"Failed to identify required column '{col}' in the catalogue."
+                f"Failed to identify required column corresponding to '{col}' in the catalogue."
                 " Please ensure that catalogue column headers match those in mapping file."
             )      
                 

--- a/simms/parser_config/skysim.py
+++ b/simms/parser_config/skysim.py
@@ -42,6 +42,7 @@ def runit(**kwargs):
     elif opts.cat_species:
         map_path = f"{thisdir}/library/{opts.cat_species}.yaml"
     else:
+        print("Warning: No mapping file specified nor built-in map selected. Using default catalogue template")
         map_path = f"{thisdir}/library/catalogue_template.yaml"
 
     mapdata = OmegaConf.load(map_path)
@@ -84,7 +85,15 @@ def runit(**kwargs):
                     value += mapcols[key][2]
                 
                 mapcols[key][1].append(value)
-                
+    
+    # validate mapcols to ensure that the required columns were read successfully
+    required_cols = ["name", "ra", "dec", "stokes_i"]
+    for col in required_cols:
+        if not mapcols[col][1]: # if the list storing column's data is empty
+            raise CatalogueError(
+                f"Failed to identify required column '{col}' in the catalogue."
+                " Please ensure that catalogue column headers match those in mapping file."
+            )      
                 
     ms_dsl = xds_from_ms(ms, index_cols=["TIME", "ANTENNA1", "ANTENNA2"], chunks={"row":10000})               
     spw_ds = xds_from_table(f"{ms}::SPECTRAL_WINDOW")[0]

--- a/simms/parser_config/skysim.py
+++ b/simms/parser_config/skysim.py
@@ -94,7 +94,8 @@ def runit(**kwargs):
                     f"Failed to identify required column corresponding to source name/ID in the catalogue."
                     " Please ensure that catalogue column headers match those in mapping file."
                 )
-            raise CatalogueError(
+            else:
+                raise CatalogueError(
                 f"Failed to identify required column corresponding to '{col}' in the catalogue."
                 " Please ensure that catalogue column headers match those in mapping file."
             )      


### PR DESCRIPTION
This is a fix for the error arising when neither "--mapping" nor "--cat-species" was set. When this happens, _skysim_ defaults to the "catalogue_template.yaml" mapping file. The problem arises because if your catalogue headers do not match the default ones in "catalogue_template.yaml", _skysim_ will fail to assign the relevant catalogue entries to the lists storing the required parameters for creating objects of the Source class. I have printed a warning when "--mapping" and "--cat-species" are not set to say we're assuming the default column names from "catalogue_template.yaml." Before _skysim_ tries to make objects of the Source class, I have also added a validation step to check if the required parameters were read successfully, raising an error if not.