### PR TITLE
Corrected noise computation in get_noise() for single SEFD case.

### DIFF
--- a/simms/telescope/generate_ms.py
+++ b/simms/telescope/generate_ms.py
@@ -172,8 +172,8 @@ def create_ms(
         
     expanded_src_elevations = np.array(expanded_src_elevations).flatten()
     
-     
-     
+    
+    
     flag_row = np.zeros(num_rows, dtype=bool)
         
     if low_source_limit:
@@ -358,7 +358,7 @@ def get_noise(sefds: Union[List, float], ntime: int, dtime: int, chan_width: flo
     """
 
     if isinstance(sefds, (int, float)):
-        noise = np.sqrt(sefds / (2 * chan_width * dtime))
+        noise = sefds / np.sqrt(2 * chan_width * dtime)
         return noise
 
     sefd_pairs = list(combinations(sefds, 2))


### PR DESCRIPTION
Fixed calculation error where square root was incorrectly applied to single SEFD values during noise calculation.