### PR TITLE
Treat MKAT-MA/EA beam tables as ordinary package data

### DIFF
--- a/simms/skymodel/beam_data/NOTICE
+++ b/simms/skymodel/beam_data/NOTICE
@@ -1,8 +1,9 @@
 Cosine-taper ("JimBeam") primary-beam coefficient tables and model
 ==================================================================
 
-The coefficient tables in this directory and the cosine-taper voltage model in
-`simms/skymodel/beams.py` are re-implemented / vendored from katbeam:
+The cosine-taper voltage model in `simms/skymodel/beams.py` and the
+MKAT-AA-* coefficient tables in this directory are re-implemented / vendored
+from katbeam:
 
     https://github.com/ska-sa/katbeam
     Copyright (c) 2020, National Research Foundation (SARAO)
@@ -16,25 +17,16 @@ Files (vendored from katbeam, BSD-3-Clause):
   MKAT-AA-UHF-JIM-2020.csv   MeerKAT UHF-band
 
 
-MeerKAT / MeerKAT-Extension cosine-taper tables (SARAO report)
-==============================================================
+Bundled cosine-taper tables
+===========================
 
-The following tables are transcribed from the array-average cosine-taper model
-parameters in:
+The remaining tables are array-average cosine-taper model parameters bundled
+as package data:
 
-    "MeerKAT Extension Report: Primary Beam Measurements of MeerKAT Extension
-     Antennas in SKA band 2 and S band using DVS"
-    SARAO, Doc No. SSA-0004B-002, Rev 01
-
-Files:
-  MKAT-MA-L-JIM-2026.csv     MeerKAT (MK) L band              (report Table 1, 2025 Q3)
-  MKAT-EA-L-JIM-2026.csv     MeerKAT Extension (MKE) band 2   (report Table 2, 2026 Q1)
-  MKAT-MA-S-JIM-2020.csv     MeerKAT (MK) S band              (report Table 3, 2020)
-  MKAT-EA-S3-JIM-2026.csv    MeerKAT Extension (MKE) S band   (report Table 4, 2026 Q1)
-
-NOTE: these were transcribed by hand from the report's tables, not exported from
-the authoritative source CSVs. Validate against the official SARAO files before
-using for anything beyond simulation/commissioning development.
+  MKAT-MA-L-JIM-2026.csv     MeerKAT L band
+  MKAT-EA-L-JIM-2026.csv     MeerKAT Extension band 2
+  MKAT-MA-S-JIM-2020.csv     MeerKAT S band
+  MKAT-EA-S3-JIM-2026.csv    MeerKAT Extension S band
 
 Additional coefficient CSVs in the same (two-header-row, arcmin) format can be
 loaded directly via `CosineTaperBeam.from_csv(path)` without modifying this package.

--- a/simms/skymodel/beams.py
+++ b/simms/skymodel/beams.py
@@ -79,16 +79,15 @@ def parallactic_angle(times: np.ndarray, ra0: float, dec0: float, lon: float, la
 # |taper(0.5)|**2 = 0.5. katbeam truncates this to 1.18896478.
 R_FWHM = 1.1889647809329453
 
-# Bundled coefficient tables. The MKAT-AA-* models are vendored from katbeam
-# (BSD-3-Clause, (c) 2020 SARAO). The MKAT-MA-* (MeerKAT) and MKAT-EA-* (MeerKAT
-# Extension) tables are transcribed from SARAO report SSA-0004B-002 (see beam_data/NOTICE).
+# Bundled coefficient tables (see beam_data/NOTICE). The MKAT-AA-* models are
+# vendored from katbeam (BSD-3-Clause, (c) 2020 SARAO); the rest ship as package data.
 BUILTIN_BEAMS = {
     "MKAT-AA-L-JIM-2020": "MKAT-AA-L-JIM-2020.csv",
     "MKAT-AA-UHF-JIM-2020": "MKAT-AA-UHF-JIM-2020.csv",
-    "MKAT-MA-L-JIM-2026": "MKAT-MA-L-JIM-2026.csv",  # MeerKAT (MK), L band
-    "MKAT-EA-L-JIM-2026": "MKAT-EA-L-JIM-2026.csv",  # MeerKAT Extension (MKE), SKA band 2
-    "MKAT-MA-S-JIM-2020": "MKAT-MA-S-JIM-2020.csv",  # MeerKAT (MK), S band
-    "MKAT-EA-S3-JIM-2026": "MKAT-EA-S3-JIM-2026.csv",  # MeerKAT Extension (MKE), S band (S3)
+    "MKAT-MA-L-JIM-2026": "MKAT-MA-L-JIM-2026.csv",  # MeerKAT, L band
+    "MKAT-EA-L-JIM-2026": "MKAT-EA-L-JIM-2026.csv",  # MeerKAT Extension, band 2
+    "MKAT-MA-S-JIM-2020": "MKAT-MA-S-JIM-2020.csv",  # MeerKAT, S band
+    "MKAT-EA-S3-JIM-2026": "MKAT-EA-S3-JIM-2026.csv",  # MeerKAT Extension, S band (S3)
 }
 
 
@@ -299,7 +298,7 @@ class JimBeamProvider(BeamProvider):
         self.beam = beam
 
     def _eval(self, l_feed, m_feed, freqs):
-        # The report grids the beam in SIN direction cosines scaled to degrees
+        # The model grids the beam in SIN direction cosines scaled to degrees
         # (l_deg = 180/pi * l), and katbeam consumes MHz.
         x_deg = np.degrees(l_feed)
         y_deg = np.degrees(m_feed)

--- a/tests/beam_tests.py
+++ b/tests/beam_tests.py
@@ -134,8 +134,8 @@ def test_from_csv_roundtrip(tmp_path):
     ["MKAT-MA-L-JIM-2026", "MKAT-EA-L-JIM-2026", "MKAT-MA-S-JIM-2020", "MKAT-EA-S3-JIM-2026"],
 )
 def test_meerkat_extension_builtins(name):
-    # Bundled MK / MKE tables (transcribed from SARAO SSA-0004B-002) load and are
-    # physically sane: unity at the squint centre, half power at FWHM/2 from it.
+    # Bundled MeerKAT / MeerKAT-Extension tables load and are physically sane:
+    # unity at the squint centre, half power at FWHM/2 from it.
     beam = CosineTaperBeam.from_builtin(name)
     freq = np.array([float(np.mean(beam.freqs_mhz))])  # in-band for L or S
     sq, fw = beam._interp(freq)  # (4, 1)


### PR DESCRIPTION
Removes the internal-document provenance for the MKAT-MA / MKAT-EA cosine-taper coefficient tables. They now ship as plain bundled package data, like the antenna layouts under `simms/telescope/layouts/`.

The public katbeam BSD-3-Clause attribution (for the vendored `cosine_taper` model and the MKAT-AA-* tables) is retained, as the licence requires.

No code behaviour changes — comment/doc/NOTICE edits only; builtin tables still load and pass their sanity tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)