### PR TITLE
Centre the primary beam on POINTING.DIRECTION (pb-command + skysim, closes #139)

### DIFF
--- a/simms/apps/skysim.py
+++ b/simms/apps/skysim.py
@@ -86,7 +86,13 @@ class _BeamContext:
             tnames, mount, beam_config, opts.beam_band
         )
         self.lon, self.lat = _array_lonlat(pos)
-        self.ra0, self.dec0, self.ncorr = ra0, dec0, ncorr
+        # The beam is centred on the antenna pointing centre (POINTING.DIRECTION), not the phase
+        # centre; source l/m are prepared for the phase centre, so keep it too for reprojection.
+        from simms.skymodel.beams import read_pointing_centre
+
+        self.phase_ra0, self.phase_dec0 = ra0, dec0
+        self.ra0, self.dec0 = read_pointing_centre(ms, ra0, dec0)
+        self.ncorr = ncorr
         self.t_start = float(t0)
         self.duration = float(t1 - t0) + float(interval)
         self.pa_step = opts.beam_pa_step
@@ -124,6 +130,8 @@ class _BeamContext:
             self.duration,
             self.pa_step,
             mid_freq,
+            phase_ra0=self.phase_ra0,
+            phase_dec0=self.phase_dec0,
         )
 
     def attach(self, prepared):
@@ -157,6 +165,8 @@ class _BeamContext:
             self.ncorr,
             full_jones=self.full_jones,
             basis_transform=basis_transform,
+            phase_ra0=self.phase_ra0,
+            phase_dec0=self.phase_dec0,
         )
 
 

--- a/simms/skymodel/beams.py
+++ b/simms/skymodel/beams.py
@@ -664,6 +664,43 @@ def array_lonlat(positions):
     return loc.lon.to_value(u.rad), loc.lat.to_value(u.rad)
 
 
+def read_pointing_centre(ms, fallback_ra0, fallback_dec0):
+    """Antenna pointing centre (radians) from ``POINTING.DIRECTION``.
+
+    This is where the dishes point, and hence where the primary beam is centred -- distinct
+    from ``FIELD.PHASE_DIR`` (the correlator phase centre, a freely-shiftable quantity). Reads
+    the poly order-0 term of the first row's direction (J2000 RA/Dec) and falls back to the
+    given phase centre, with a warning, when the MS has no usable POINTING table.
+    """
+    from daskms import xds_from_table
+
+    try:
+        pnt = xds_from_table(f"{ms}::POINTING")[0]
+        direction = pnt.DIRECTION.data
+        if direction.shape[0] == 0:
+            raise ValueError("empty POINTING table")
+        radec = np.asarray(direction[0, 0].compute(), dtype=np.float64)
+        return float(radec[0]), float(radec[1])
+    except Exception as exc:
+        log.warning("No usable POINTING.DIRECTION (%s); using the phase centre as the beam centre.", exc)
+        return float(fallback_ra0), float(fallback_dec0)
+
+
+def reproject_lm(ell, emm, from_ra0, from_dec0, to_ra0, to_dec0):
+    """Re-reference direction cosines from one tangent centre to another (a no-op if they match).
+
+    Source ``(l, m)`` prepared for the phase centre are re-expressed relative to the beam
+    (pointing) centre, so the beam is sampled at each source's offset from where the dish points.
+    """
+    if from_ra0 == to_ra0 and from_dec0 == to_dec0:
+        return ell, emm
+    from simms.skymodel.fits_skies import lm_to_radec
+    from simms.utilities import radec2lm
+
+    ra, dec = lm_to_radec(np.asarray(ell), np.asarray(emm), from_ra0, from_dec0)
+    return radec2lm(to_ra0, to_dec0, ra, dec)
+
+
 def resolve_beam(spec, band: str = "L") -> BeamProvider:
     """Build a beam provider from a spec: a ``.fits`` cube, a CSV/built-in JimBeam, or a band."""
     spec = band if spec in (None, "") else str(spec)

--- a/simms/skymodel/fits_skies.py
+++ b/simms/skymodel/fits_skies.py
@@ -262,6 +262,8 @@ def attach_image_beam(
     duration: float,
     pa_step: float,
     mid_freq: float,
+    phase_ra0: float | None = None,
+    phase_dec0: float | None = None,
 ) -> PreparedFitsSky:
     """Multiply the apparent sky by a parallactic-angle-averaged power beam (in place).
 
@@ -270,13 +272,19 @@ def attach_image_beam(
     heterogeneity and cross-hand leakage -- correct only for a homogeneous array. The
     beam is applied per channel where the model has a real channel axis (DFT components,
     a spectral CUBE), otherwise at the band mid-frequency (single FLAT/POLY plane).
+
+    ``ra0``/``dec0`` are the beam (antenna pointing) centre; ``phase_ra0``/``phase_dec0`` are
+    the phase centre the image ``l/m`` are referenced to, so the beam is sampled at each pixel's
+    offset from where the dish points.
     """
-    from simms.skymodel.beams import image_power_beam, pa_sample_grid
+    from simms.skymodel.beams import image_power_beam, pa_sample_grid, reproject_lm
 
     _, chi_grid = pa_sample_grid(t_start, duration, ra0, dec0, lon, lat, pa_step)
 
     if prepared.backend == "dft":
         ell, emm = prepared.lmn[:, 0], prepared.lmn[:, 1]
+        if phase_ra0 is not None:
+            ell, emm = reproject_lm(ell, emm, phase_ra0, phase_dec0, ra0, dec0)
         power = image_power_beam(provider, is_altaz, ell, emm, prepared.chan_freqs, chi_grid)
         prepared.bmat *= power[:, None, :]  # (ncomp, nspec, nchan)
         return prepared
@@ -284,9 +292,12 @@ def attach_image_beam(
     npix_l, npix_m, nchan_model = prepared.planes.shape[1], prepared.planes.shape[2], prepared.planes.shape[3]
     i_pix, j_pix = (a.ravel() for a in np.meshgrid(np.arange(npix_l), np.arange(npix_m), indexing="ij"))
     lmn = prepared.grid.pixel_lmn(i_pix, j_pix)
+    ell, emm = lmn[:, 0], lmn[:, 1]
+    if phase_ra0 is not None:
+        ell, emm = reproject_lm(ell, emm, phase_ra0, phase_dec0, ra0, dec0)
     per_channel = nchan_model == prepared.chan_freqs.size
     freqs = prepared.chan_freqs if per_channel else np.array([mid_freq])
-    power = image_power_beam(provider, is_altaz, lmn[:, 0], lmn[:, 1], freqs, chi_grid)
+    power = image_power_beam(provider, is_altaz, ell, emm, freqs, chi_grid)
     prepared.planes *= power.reshape(npix_l, npix_m, freqs.size)[None]
     return prepared
 

--- a/simms/skymodel/mstools.py
+++ b/simms/skymodel/mstools.py
@@ -339,19 +339,32 @@ def attach_beam(
     ncorr: int,
     full_jones: bool = False,
     basis_transform: np.ndarray | None = None,
+    phase_ra0: float | None = None,
+    phase_dec0: float | None = None,
 ) -> PreparedSky:
     """Return a copy of ``prepared`` with a primary-beam grid attached.
 
     Samples each type's beam on a parallactic-angle grid spanning the observation
     (built once, sliced per channel-chunk by :meth:`PreparedSky.select_channels`).
-    ``prepared`` must carry the full-width brightness (``nspec == ncorr``). With
-    ``full_jones`` the grid holds 2x2 Jones (folding ``basis_transform``) and the
-    ``predict_vis_jones`` kernel is used; otherwise the diagonal per-feed grid.
+    ``ra0``/``dec0`` are the beam (antenna pointing) centre; ``phase_ra0``/``phase_dec0``
+    are the phase centre the source ``l/m`` were prepared for, so the beam is sampled at each
+    source's offset from where the dish points. ``prepared`` must carry the full-width
+    brightness (``nspec == ncorr``). With ``full_jones`` the grid holds 2x2 Jones (folding
+    ``basis_transform``) and the ``predict_vis_jones`` kernel is used; otherwise the diagonal
+    per-feed grid.
     """
-    from simms.skymodel.beams import build_beam_grid, build_beam_grid_jones, corr_feed_maps, pa_sample_grid
+    from simms.skymodel.beams import (
+        build_beam_grid,
+        build_beam_grid_jones,
+        corr_feed_maps,
+        pa_sample_grid,
+        reproject_lm,
+    )
 
     tgrid, chi_grid = pa_sample_grid(t_start, duration, ra0, dec0, lon, lat, pa_step)
     ell, emm = prepared.lmn[:, 0], prepared.lmn[:, 1]
+    if phase_ra0 is not None:
+        ell, emm = reproject_lm(ell, emm, phase_ra0, phase_dec0, ra0, dec0)
     if full_jones:
         beam_grid = build_beam_grid_jones(providers, type_is_altaz, ell, emm, prepared.freqs, chi_grid, basis_transform)
         corr_feed_p = corr_feed_q = None

--- a/simms/skymodel/pb_ops.py
+++ b/simms/skymodel/pb_ops.py
@@ -21,35 +21,12 @@ log = logging.getLogger(BIN.primary_beam)
 # --------------------------------------------------------------------- geometry
 
 
-def _beam_centre(ms, phase_dir):
-    """Antenna pointing centre (radians) -- the primary beam sits here, not on the phase centre.
-
-    Reads ``POINTING.DIRECTION`` (J2000 RA/Dec, poly order 0), which is the direction the
-    dishes are commanded to; the correlator phase centre (``FIELD.PHASE_DIR``) is a separate,
-    freely-shiftable quantity. Falls back to the phase centre when the MS has no usable
-    POINTING table (common for externally produced MSs).
-    """
-    from daskms import xds_from_table
-
-    try:
-        pnt = xds_from_table(f"{ms}::POINTING")[0]
-        direction = pnt.DIRECTION.data
-        if direction.shape[0] == 0:
-            raise ValueError("empty POINTING table")
-        # (row, poly, radec): first antenna/time row, constant-term of the direction polynomial.
-        radec = np.asarray(direction[0, 0].compute(), dtype=np.float64)
-        return float(radec[0]), float(radec[1])
-    except Exception as exc:
-        log.warning("No usable POINTING.DIRECTION (%s); using the phase centre as the beam centre.", exc)
-        return float(phase_dir[0][0]), float(phase_dir[0][1])
-
-
 def _observation(ms, field_id=0, spw_id=0):
     """Read the geometry an averaged beam needs from an MS (for the given field/spw)."""
     import dask
     from daskms import xds_from_ms, xds_from_table
 
-    from simms.skymodel.beams import array_lonlat
+    from simms.skymodel.beams import array_lonlat, read_pointing_centre
 
     ant = xds_from_table(f"{ms}::ANTENNA")[0]
     spw = xds_from_table(f"{ms}::SPECTRAL_WINDOW")[0]
@@ -64,7 +41,8 @@ def _observation(ms, field_id=0, spw_id=0):
         field.PHASE_DIR.data[int(field_id)],
     )
     lon, lat = array_lonlat(pos)
-    ra0, dec0 = _beam_centre(ms, phase_dir)  # antenna pointing centre, not the phase centre
+    # Beam centre is the antenna pointing centre, not the phase centre.
+    ra0, dec0 = read_pointing_centre(ms, phase_dir[0][0], phase_dir[0][1])
     return {
         "t_start": float(t0),
         "duration": float(t1 - t0) + float(interval),

--- a/simms/skymodel/pb_ops.py
+++ b/simms/skymodel/pb_ops.py
@@ -21,6 +21,29 @@ log = logging.getLogger(BIN.primary_beam)
 # --------------------------------------------------------------------- geometry
 
 
+def _beam_centre(ms, phase_dir):
+    """Antenna pointing centre (radians) -- the primary beam sits here, not on the phase centre.
+
+    Reads ``POINTING.DIRECTION`` (J2000 RA/Dec, poly order 0), which is the direction the
+    dishes are commanded to; the correlator phase centre (``FIELD.PHASE_DIR``) is a separate,
+    freely-shiftable quantity. Falls back to the phase centre when the MS has no usable
+    POINTING table (common for externally produced MSs).
+    """
+    from daskms import xds_from_table
+
+    try:
+        pnt = xds_from_table(f"{ms}::POINTING")[0]
+        direction = pnt.DIRECTION.data
+        if direction.shape[0] == 0:
+            raise ValueError("empty POINTING table")
+        # (row, poly, radec): first antenna/time row, constant-term of the direction polynomial.
+        radec = np.asarray(direction[0, 0].compute(), dtype=np.float64)
+        return float(radec[0]), float(radec[1])
+    except Exception as exc:
+        log.warning("No usable POINTING.DIRECTION (%s); using the phase centre as the beam centre.", exc)
+        return float(phase_dir[0][0]), float(phase_dir[0][1])
+
+
 def _observation(ms, field_id=0, spw_id=0):
     """Read the geometry an averaged beam needs from an MS (for the given field/spw)."""
     import dask
@@ -41,14 +64,15 @@ def _observation(ms, field_id=0, spw_id=0):
         field.PHASE_DIR.data[int(field_id)],
     )
     lon, lat = array_lonlat(pos)
+    ra0, dec0 = _beam_centre(ms, phase_dir)  # antenna pointing centre, not the phase centre
     return {
         "t_start": float(t0),
         "duration": float(t1 - t0) + float(interval),
         "lon": lon,
         "lat": lat,
         "freqs": np.asarray(chan_freq, dtype=np.float64),
-        "ra0": float(phase_dir[0][0]),
-        "dec0": float(phase_dir[0][1]),
+        "ra0": ra0,
+        "dec0": dec0,
     }
 
 
@@ -58,6 +82,19 @@ def _averaged_beam(provider, ell, emm, ra0, dec0, obs, pa_step):
 
     _, chi_grid = pa_sample_grid(obs["t_start"], obs["duration"], ra0, dec0, obs["lon"], obs["lat"], pa_step)
     return averaged_power_beam(provider, ell, emm, obs["freqs"], chi_grid)
+
+
+def _angular_separation(ra1, dec1, ra2, dec2):
+    """Great-circle angle (radians) between two directions given in radians."""
+    return float(
+        np.arccos(
+            np.clip(
+                np.sin(dec1) * np.sin(dec2) + np.cos(dec1) * np.cos(dec2) * np.cos(ra1 - ra2),
+                -1.0,
+                1.0,
+            )
+        )
+    )
 
 
 # --------------------------------------------------------------------- to-fits
@@ -162,14 +199,30 @@ def apply_correct_image(opts, invert):
         out_dtype = hdul[0].data.dtype
 
     cel = WCS(header).celestial
-    ra0 = np.radians(cel.wcs.crval[cel.wcs.lng])
-    dec0 = np.radians(cel.wcs.crval[cel.wcs.lat])
+    # The primary beam sits on the antenna pointing centre (POINTING.DIRECTION) -- not the
+    # correlator phase centre, and not necessarily the image's reference pixel. Centre the beam
+    # (pixel l/m and the PA track) there; the image WCS only maps pixels to world coordinates.
+    obs = _observation(opts.ms, opts.field_id, opts.spw_id)
+    ra0, dec0 = obs["ra0"], obs["dec0"]
+    img_ra0 = np.radians(cel.wcs.crval[cel.wcs.lng])
+    img_dec0 = np.radians(cel.wcs.crval[cel.wcs.lat])
+    sep = _angular_separation(img_ra0, img_dec0, ra0, dec0)
+    if sep > np.radians(1.0 / 3600.0):  # > 1 arcsec: image reference and antenna pointing disagree
+        log.warning(
+            "Image reference pixel (%.6f, %.6f deg) differs from the antenna pointing centre "
+            "(%.6f, %.6f deg) by %.1f arcsec; centring the beam on the pointing centre.",
+            np.degrees(img_ra0),
+            np.degrees(img_dec0),
+            np.degrees(ra0),
+            np.degrees(dec0),
+            np.degrees(sep) * 3600.0,
+        )
+
     # Standard axis order: FITS axis 1 = RA (numpy last), axis 2 = DEC (numpy second-last).
     npix_dec, npix_ra = data.shape[-2], data.shape[-1]
     i_ra, j_dec = np.meshgrid(np.arange(npix_ra), np.arange(npix_dec))  # (npix_dec, npix_ra)
 
     ell, emm = pixel_lm(cel, ra0, dec0, i_ra.ravel(), j_dec.ravel())
-    obs = _observation(opts.ms, opts.field_id, opts.spw_id)
     A = _averaged_beam(provider_from(opts), ell, emm, ra0, dec0, obs, opts.beam_pa_step)
     A = A.reshape(npix_dec, npix_ra)
 

--- a/tests/predict_beam_e2e_tests.py
+++ b/tests/predict_beam_e2e_tests.py
@@ -108,6 +108,44 @@ def test_beam_attenuates_and_differs_from_nobeam(e2e):
     assert np.abs(beam).max() > 0
 
 
+def _set_pointing_direction(ms, ra_rad, dec_rad):
+    """Overwrite POINTING.DIRECTION so it differs from FIELD.PHASE_DIR (which simms keeps equal)."""
+    import dask
+    import dask.array as da
+    from daskms import xds_from_table, xds_to_table
+
+    pnt = xds_from_table(f"{ms}::POINTING")[0]
+    nrow = pnt.DIRECTION.shape[0]
+    newdir = np.broadcast_to(np.array([ra_rad, dec_rad]), (nrow, 1, 2)).copy()
+    pnt = pnt.assign(DIRECTION=(("row", "point-poly", "radec"), da.from_array(newdir, chunks=(nrow, 1, 2))))
+    dask.compute(xds_to_table([pnt], f"{ms}::POINTING", columns=["DIRECTION"]))
+
+
+def test_beam_follows_pointing_direction(e2e):
+    # A source sitting exactly on the phase centre.
+    from daskms import xds_from_table
+
+    sky = e2e.random_named_file(suffix=".txt")
+    with open(sky, "w") as fh:
+        fh.write("#format: name ra dec stokes_i\n")
+        fh.write("S 0h0m20s -30d0m0s 4.0\n")  # == the fixture's pointing/phase centre
+
+    # Baseline: POINTING.DIRECTION == PHASE_DIR (as simms writes), so the source is on-axis.
+    skysim.runit(_opts(e2e.ms, sky, primary_beam=e2e.beams, column="ALIGNED"))
+
+    # Point the dishes 0.8 deg south of the phase centre; the same source is now off-axis.
+    cur = np.asarray(xds_from_table(f"{e2e.ms}::POINTING")[0].DIRECTION.data[0, 0].compute())
+    _set_pointing_direction(e2e.ms, float(cur[0]), float(cur[1]) - np.radians(0.8))
+    skysim.runit(_opts(e2e.ms, sky, primary_beam=e2e.beams, column="OFFSET"))
+
+    ds = xds_from_ms(e2e.ms)[0]
+    aligned = np.abs(ds.ALIGNED.data.compute()).mean()
+    offset = np.abs(ds.OFFSET.data.compute()).mean()
+    # The on-phase-centre source is attenuated more once the dishes point elsewhere. Under the
+    # old phase-centre logic the beam would ignore the pointing shift and the two would match.
+    assert offset < 0.9 * aligned
+
+
 def test_beam_rejects_nonlinear_correlations(e2e):
     # A circular-correlation MS must be refused: the beam's feed mapping is linear-only.
     ms = e2e.random_named_directory(suffix=".ms")

--- a/tests/primary_beam_tests.py
+++ b/tests/primary_beam_tests.py
@@ -1,8 +1,11 @@
 """Tests for the `simms primary-beam` utility (to-fits, tag-ms, apply, correct)."""
 
+import logging
+
 import numpy as np
 import pytest
 from astropy.io import fits
+from astropy.wcs import WCS
 from daskms import xds_from_table
 from omegaconf import OmegaConf
 
@@ -11,7 +14,7 @@ from simms.skymodel.beams import CosineTaperBeam, FitsBeamProvider, JimBeamProvi
 from simms.telescope.generate_ms import create_ms
 
 from . import InitTest
-from .predict_fits_tests import make_header
+from .predict_fits_tests import DEC0_DEG, RA0_DEG, make_header
 
 
 def _opts(mode, **over):
@@ -150,6 +153,64 @@ def test_apply_then_correct_image_is_identity(fx):
     np.testing.assert_allclose(rec[offsrc], original[offsrc], rtol=1e-4)
     # Corners (beam below cutoff) are blanked by correct.
     assert np.isnan(rec[0, 0])
+
+
+def test_apply_centres_beam_on_pointing_centre(fx, caplog):
+    # Image reference pixel offset 0.4 deg north of the pointing centre (dec -31). The primary
+    # beam belongs to the antenna pointing centre (POINTING.DIRECTION), not the image reference.
+    npix = 256
+    header = make_header(npix, nstokes=1, nchan=1, crval2=DEC0_DEG + 0.4)
+    img = fx.random_named_file(suffix=".fits")
+    fits.PrimaryHDU(data=np.ones((npix, npix), np.float32), header=header).writeto(img)
+
+    out = fx.random_named_file(suffix=".fits")
+    with caplog.at_level(logging.WARNING):
+        primary_beam.runit(_opts("apply", ms=fx.ms, fits_sky=img, output=out, log_level="WARNING"))
+    assert any("pointing centre" in r.message for r in caplog.records)
+
+    # Uniform input -> the apparent image *is* the power beam A(l, m). It must peak on the
+    # pointing centre, not on the image reference pixel (which is 0.4 deg off it).
+    app = fits.getdata(out)
+    ((col, row),) = WCS(header).celestial.wcs_world2pix([[RA0_DEG, DEC0_DEG]], 0)
+    pc = (int(round(row)), int(round(col)))  # numpy [dec, ra]
+    ref = (npix // 2, npix // 2)  # image reference pixel
+    assert app[pc] > app[ref]  # would fail if the beam were centred on the image reference
+    assert app[pc] > 0.9  # ~on-axis at the pointing centre
+
+
+def _set_pointing_direction(ms, ra_rad, dec_rad):
+    """Overwrite POINTING.DIRECTION so it differs from FIELD.PHASE_DIR (which simms keeps equal)."""
+    import dask
+    import dask.array as da
+    from daskms import xds_from_table, xds_to_table
+
+    pnt = xds_from_table(f"{ms}::POINTING")[0]
+    nrow = pnt.DIRECTION.shape[0]
+    newdir = np.broadcast_to(np.array([ra_rad, dec_rad]), (nrow, 1, 2)).copy()
+    pnt = pnt.assign(DIRECTION=(("row", "point-poly", "radec"), da.from_array(newdir, chunks=(nrow, 1, 2))))
+    dask.compute(xds_to_table([pnt], f"{ms}::POINTING", columns=["DIRECTION"]))
+
+
+def test_apply_uses_pointing_direction_not_phase_centre(fx):
+    # Point the dishes 0.3 deg north of the phase centre; the image WCS stays on the phase centre.
+    _set_pointing_direction(fx.ms, np.radians(RA0_DEG), np.radians(DEC0_DEG + 0.3))
+
+    npix = 256
+    header = make_header(npix, nstokes=1, nchan=1)  # reference == phase centre (dec -31)
+    img = fx.random_named_file(suffix=".fits")
+    fits.PrimaryHDU(data=np.ones((npix, npix), np.float32), header=header).writeto(img)
+
+    out = fx.random_named_file(suffix=".fits")
+    primary_beam.runit(_opts("apply", ms=fx.ms, fits_sky=img, output=out))
+
+    # The beam must follow POINTING.DIRECTION (dec -30.7), not FIELD.PHASE_DIR (dec -31).
+    app = fits.getdata(out)
+    wcs = WCS(header).celestial
+    ((pc_col, pc_row),) = wcs.wcs_world2pix([[RA0_DEG, DEC0_DEG + 0.3]], 0)  # pointing pixel
+    pnt_pix = (int(round(pc_row)), int(round(pc_col)))
+    phase_pix = (npix // 2, npix // 2)  # phase centre / image reference pixel
+    assert app[pnt_pix] > app[phase_pix]  # follows POINTING, not PHASE_DIR
+    assert app[pnt_pix] > 0.9
 
 
 def test_apply_then_correct_ascii_is_identity(fx):


### PR DESCRIPTION
Closes #139.

## Problem
The primary beam was centred on the **correlator phase centre** (`FIELD.PHASE_DIR`), but the phase centre is arbitrary and freely shiftable on demand. The beam physically sits where the dishes point — the antenna pointing centre in `POINTING.DIRECTION`. When the two differ (real data, or a shifted phase centre), the beam was applied centred on the wrong place. This affected both the `primary-beam apply`/`correct` command and the `skysim` prediction path.

## Fix
A shared helper `read_pointing_centre(ms, fallback_ra0, fallback_dec0)` (in `beams.py`) reads the pointing centre from `POINTING.DIRECTION` (J2000 RA/Dec, poly order 0), falling back to the phase centre **with a warning** when the MS has no usable POINTING table.

**primary-beam command** (`pb_ops`): `_observation` derives the beam centre from `POINTING.DIRECTION`. `apply_correct_image` centres both the pixel l/m grid and the PA track there, and warns when the image WCS reference disagrees with the pointing centre by more than 1 arcsec.

**skysim** (`_BeamContext`): the per-antenna beam is now centred on the pointing centre. Because the prepared source l/m are referenced to the phase centre (for the visibility phasor), the beam-sampling offsets are reprojected from the phase centre onto the pointing centre via a new `reproject_lm` helper — a **no-op** when the two coincide (as in simms-made MSs, which broadcast `POINTING.DIRECTION` from the phase dir), so existing behaviour is unchanged. Applied on the component/wsclean path (`attach_beam`) and both the DFT and planes FITS-image paths (`attach_image_beam`).

## Tests (191 passing)
- `test_apply_centres_beam_on_pointing_centre`: image WCS reference offset from the pointing centre; the beam peaks on the pointing centre and the mismatch warning fires.
- `test_apply_uses_pointing_direction_not_phase_centre`: `POINTING.DIRECTION` set 0.3 deg off `PHASE_DIR`; the beam follows POINTING, not the phase centre.
- `test_beam_follows_pointing_direction` (skysim e2e): shifting `POINTING.DIRECTION` 0.8 deg off the phase centre attenuates an on-phase-centre source — which the old phase-centre logic would have ignored.

## Note
Frame handling assumes `POINTING.DIRECTION` is J2000/ICRS RA/Dec (as simms writes, and as target-tracking MSs conventionally store). An AZEL pointing column would need a per-time frame transform; out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)