### PR TITLE
Bound beam-grid memory with a configurable ceiling (#140)

### DIFF
--- a/simms/apps/simms-cabs.yaml
+++ b/simms/apps/simms-cabs.yaml
@@ -141,6 +141,14 @@ cabs:
           interpolated from. Smaller is more accurate but uses more memory/compute.
         dtype: float
         default: 1.0
+      beam-grid-max-gib:
+        info: >-
+          Hard ceiling (GiB) on the sampled beam grid, which scales with parallactic-angle
+          samples x sky components x channels and is held in memory for the whole run.
+          skysim errors (rather than risking an out-of-memory kill) if the grid would exceed
+          this; lower it with a coarser --beam-pa-step or fewer components.
+        dtype: float
+        default: 4.0
       beam-jones:
         info: >-
           Primary-beam application for component skies. "diagonal" applies a per-feed

--- a/simms/apps/skysim.py
+++ b/simms/apps/skysim.py
@@ -96,6 +96,7 @@ class _BeamContext:
         self.t_start = float(t0)
         self.duration = float(t1 - t0) + float(interval)
         self.pa_step = opts.beam_pa_step
+        self.beam_grid_max_gib = opts.beam_grid_max_gib
 
     @property
     def brightness_linear_basis(self):
@@ -167,6 +168,7 @@ class _BeamContext:
             basis_transform=basis_transform,
             phase_ra0=self.phase_ra0,
             phase_dec0=self.phase_dec0,
+            beam_grid_max_gib=self.beam_grid_max_gib,
         )
 
 

--- a/simms/skymodel/beams.py
+++ b/simms/skymodel/beams.py
@@ -549,15 +549,59 @@ def pa_sample_grid(t_start, duration, ra0, dec0, lon, lat, pa_step_deg):
     return tgrid, chi_grid
 
 
-def build_beam_grid(providers, type_is_altaz, ell, emm, freqs, chi_grid):
+# Default hard ceiling (GiB) on the sampled beam grid. The grid is built once at full
+# size and only sliced per channel-chunk downstream, so its whole footprint lives in
+# memory for the run; --chan-chunks does not reduce it.
+BEAM_GRID_MAX_GIB_DEFAULT = 4.0
+
+
+def _beam_grid_gib(ntype, n_pa, nsrc, nchan, fold):
+    """Footprint (GiB) of a ``(ntype, n_pa, nsrc, nchan, fold)`` complex64 beam grid.
+
+    ``fold`` is 2 for the diagonal per-feed grid, 4 for the 2x2 Jones grid; complex64 is
+    8 bytes per element.
+    """
+    return ntype * n_pa * nsrc * nchan * fold * 8 / 2**30
+
+
+def _check_beam_grid_footprint(ntype, n_pa, nsrc, nchan, fold, max_gib):
+    """Warn/raise on the beam-grid footprint before it is allocated.
+
+    Warns above half the ceiling and raises :class:`MemoryError` above ``max_gib``, with an
+    actionable message naming the levers (the grid scales with PA samples x sources x
+    channels). See :data:`BEAM_GRID_MAX_GIB_DEFAULT`.
+    """
+    gib = _beam_grid_gib(ntype, n_pa, nsrc, nchan, fold)
+    dims = f"{ntype} type(s) x {n_pa} PA x {nsrc} src x {nchan} chan x {fold}"
+    if gib > max_gib:
+        raise MemoryError(
+            f"Primary-beam grid would need {gib:.2f} GiB ({dims}), above the "
+            f"{max_gib:.2f} GiB ceiling. Reduce it with a coarser --beam-pa-step (fewer PA "
+            f"samples), fewer sky components, or raise --beam-grid-max-gib. --chan-chunks "
+            f"does not help: the grid is built once for all channels."
+        )
+    if gib > 0.5 * max_gib:
+        log.warning(
+            "Primary-beam grid needs %.2f GiB (%s), over half the %.2f GiB ceiling; a "
+            "coarser --beam-pa-step or fewer components lowers it.",
+            gib,
+            dims,
+            max_gib,
+        )
+
+
+def build_beam_grid(providers, type_is_altaz, ell, emm, freqs, chi_grid, max_gib=BEAM_GRID_MAX_GIB_DEFAULT):
     """Sample every type's voltage beam on the PA grid.
 
     Returns an array of shape ``(ntype, n_pa, nsrc, nchan, 2)``. Stored as ``complex64``
     (halving this large array vs ``complex128``); a beam voltage is O(1), so single
     precision is ample and visibilities still accumulate in double. Alt-az types use
-    ``chi_grid``; others are evaluated at zero parallactic angle (no rotation).
+    ``chi_grid``; others are evaluated at zero parallactic angle (no rotation). Raises
+    :class:`MemoryError` if the grid would exceed ``max_gib`` (see
+    :func:`_check_beam_grid_footprint`).
     """
     ntype = len(providers)
+    _check_beam_grid_footprint(ntype, chi_grid.size, ell.size, freqs.size, 2, max_gib)
     grid = np.empty((ntype, chi_grid.size, ell.size, freqs.size, 2), dtype=np.complex64)
     zeros = np.zeros_like(chi_grid)
     for ti, prov in enumerate(providers):
@@ -581,14 +625,19 @@ def corr_basis_transform(is_circular: bool) -> np.ndarray:
     return _S_LIN2CIRC.copy() if is_circular else np.eye(2, dtype=np.complex128)
 
 
-def build_beam_grid_jones(providers, type_is_altaz, ell, emm, freqs, chi_grid, basis_transform):
+def build_beam_grid_jones(
+    providers, type_is_altaz, ell, emm, freqs, chi_grid, basis_transform, max_gib=BEAM_GRID_MAX_GIB_DEFAULT
+):
     """Sample every type's 2x2 voltage Jones on the PA grid, folding the basis transform.
 
     Returns ``(ntype, n_pa, nsrc, nchan, 2, 2)`` complex64 holding ``E' = S . E``, so the
     kernel's ``V = E'_p B_feed E'_q^H = S (E_p B E_q^H) S^H`` lands in the MS correlation
-    basis (``B_feed`` is the linear-feed coherency). Alt-az types use ``chi_grid``.
+    basis (``B_feed`` is the linear-feed coherency). Alt-az types use ``chi_grid``. Raises
+    :class:`MemoryError` if the grid would exceed ``max_gib`` (see
+    :func:`_check_beam_grid_footprint`).
     """
     ntype = len(providers)
+    _check_beam_grid_footprint(ntype, chi_grid.size, ell.size, freqs.size, 4, max_gib)
     grid = np.empty((ntype, chi_grid.size, ell.size, freqs.size, 2, 2), dtype=np.complex64)
     zeros = np.zeros_like(chi_grid)
     for ti, prov in enumerate(providers):

--- a/simms/skymodel/mstools.py
+++ b/simms/skymodel/mstools.py
@@ -341,6 +341,7 @@ def attach_beam(
     basis_transform: np.ndarray | None = None,
     phase_ra0: float | None = None,
     phase_dec0: float | None = None,
+    beam_grid_max_gib: float | None = None,
 ) -> PreparedSky:
     """Return a copy of ``prepared`` with a primary-beam grid attached.
 
@@ -354,6 +355,7 @@ def attach_beam(
     per-feed grid.
     """
     from simms.skymodel.beams import (
+        BEAM_GRID_MAX_GIB_DEFAULT,
         build_beam_grid,
         build_beam_grid_jones,
         corr_feed_maps,
@@ -361,15 +363,18 @@ def attach_beam(
         reproject_lm,
     )
 
+    max_gib = BEAM_GRID_MAX_GIB_DEFAULT if beam_grid_max_gib is None else beam_grid_max_gib
     tgrid, chi_grid = pa_sample_grid(t_start, duration, ra0, dec0, lon, lat, pa_step)
     ell, emm = prepared.lmn[:, 0], prepared.lmn[:, 1]
     if phase_ra0 is not None:
         ell, emm = reproject_lm(ell, emm, phase_ra0, phase_dec0, ra0, dec0)
     if full_jones:
-        beam_grid = build_beam_grid_jones(providers, type_is_altaz, ell, emm, prepared.freqs, chi_grid, basis_transform)
+        beam_grid = build_beam_grid_jones(
+            providers, type_is_altaz, ell, emm, prepared.freqs, chi_grid, basis_transform, max_gib=max_gib
+        )
         corr_feed_p = corr_feed_q = None
     else:
-        beam_grid = build_beam_grid(providers, type_is_altaz, ell, emm, prepared.freqs, chi_grid)
+        beam_grid = build_beam_grid(providers, type_is_altaz, ell, emm, prepared.freqs, chi_grid, max_gib=max_gib)
         corr_feed_p, corr_feed_q = corr_feed_maps(ncorr)
     return replace(
         prepared,

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -33,6 +33,7 @@ def skysim_opts(ms, ascii_sky=None, column="DATA", **overrides):
         "primary_beam": None,
         "beam_band": "L",
         "beam_pa_step": 1.0,
+        "beam_grid_max_gib": 4.0,
         "beam_jones": "diagonal",
         "telescope_name_column": "TELESCOPE_NAME",
         "input_column": None,

--- a/tests/beam_tests.py
+++ b/tests/beam_tests.py
@@ -573,6 +573,54 @@ def test_pa_sample_grid_caps_near_zenith_transit():
     assert tg2.size < 200
 
 
+# --- Beam-grid memory ceiling (#140) ---------------------------------------------
+
+from simms.skymodel.beams import (  # noqa: E402
+    BEAM_GRID_MAX_GIB_DEFAULT,
+    build_beam_grid,
+    build_beam_grid_jones,
+)
+
+
+def _small_grid_args():
+    providers = [UnityBeamProvider()]
+    type_is_altaz = np.array([False])
+    ell = np.array([0.0, 0.01, -0.02])
+    emm = np.array([0.0, -0.01, 0.02])
+    freqs = np.array([1.3e9, 1.4e9])
+    chi_grid = np.zeros(4)
+    return providers, type_is_altaz, ell, emm, freqs, chi_grid
+
+
+def test_build_beam_grid_raises_above_ceiling():
+    providers, type_is_altaz, ell, emm, freqs, chi_grid = _small_grid_args()
+    with pytest.raises(MemoryError, match="beam-pa-step"):
+        build_beam_grid(providers, type_is_altaz, ell, emm, freqs, chi_grid, max_gib=1e-9)
+    # The Jones grid (fold 4) is checked the same way.
+    with pytest.raises(MemoryError, match="beam-grid-max-gib"):
+        build_beam_grid_jones(
+            providers, type_is_altaz, ell, emm, freqs, chi_grid, corr_basis_transform(False), max_gib=1e-9
+        )
+
+
+def test_build_beam_grid_warns_in_soft_band(caplog):
+    providers, type_is_altaz, ell, emm, freqs, chi_grid = _small_grid_args()
+    # 1 x 4 x 3 x 2 x 2 x 8 B = 384 B; a ceiling just above it puts us over half.
+    max_gib = 5e-7
+    with caplog.at_level("WARNING", logger="simms.skysim"):
+        grid = build_beam_grid(providers, type_is_altaz, ell, emm, freqs, chi_grid, max_gib=max_gib)
+    assert grid.shape == (1, 4, 3, 2, 2)
+    assert any("half" in r.message for r in caplog.records)
+
+
+def test_build_beam_grid_default_limit_passes_quietly(caplog):
+    providers, type_is_altaz, ell, emm, freqs, chi_grid = _small_grid_args()
+    with caplog.at_level("WARNING", logger="simms.skysim"):
+        grid = build_beam_grid(providers, type_is_altaz, ell, emm, freqs, chi_grid, max_gib=BEAM_GRID_MAX_GIB_DEFAULT)
+    assert grid.shape == (1, 4, 3, 2, 2)
+    assert not caplog.records
+
+
 def test_fits_provider_handles_descending_grid():
     # FITS L/M axes commonly descend (negative CDELT); the constructor must re-sort
     # ascending rather than let RegularGridInterpolator raise, with identical results.


### PR DESCRIPTION
Follow-up from #138 (primary-beam review finding #4). Closes #140.

`build_beam_grid` / `build_beam_grid_jones` allocate a `complex64` grid of shape
`(ntype, n_pa, nsrc, nchan, 2[,2])`. It is built **once at full-channel size** in
`attach_beam` and only *sliced* per channel-chunk downstream, so the whole footprint
lives in memory for the run — `--chan-chunks` does **not** reduce it. With wideband
channelisation, dense component models, and up to `MAX_PA_SAMPLES` parallactic-angle
rows the grid could reach many GB with no estimate, warning, or ceiling.

### Change
- Estimate the footprint before allocating: **warn** above half the ceiling, **raise a
  clear `MemoryError`** above it, naming the levers (coarser `--beam-pa-step`, fewer
  components, or a higher `--beam-grid-max-gib`; and that `--chan-chunks` won't help).
- New skysim option **`--beam-grid-max-gib`** (default `4.0`), threaded through
  `attach_beam` → `build_beam_grid[_jones]`. Mirrors the existing `MAX_PA_SAMPLES` cap.
- The primary-beam / FITS-image paths are unaffected (they loop at `O(npts)`).

### Tests
`tests/beam_tests.py`: the grid raises above a tiny ceiling (diagonal and Jones),
warns in the soft band while still returning a correct-shaped grid, and passes quietly
under the default limit. Full beam suite + `predict_beam_e2e_tests.py` green; `--beam-grid-max-gib`
verified on `simms skysim --help`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
