### PR TITLE
Reject AZEL-framed POINTING.DIRECTION instead of mis-centring the beam (#144)

### DIFF
--- a/simms/skymodel/beams.py
+++ b/simms/skymodel/beams.py
@@ -663,15 +663,58 @@ def array_lonlat(positions):
     return loc.lon.to_value(u.rad), loc.lat.to_value(u.rad)
 
 
+# POINTING.DIRECTION measure frames that name a horizontal (az/el-type) direction. These
+# map to a *time-dependent* sky position, so a single fixed beam centre is meaningless.
+_HORIZONTAL_POINTING_FRAMES = frozenset({"AZEL", "AZELGEO", "AZELSW", "AZELNE", "HADEC"})
+# Equatorial frames handled silently on the fast path (a constant RA/Dec direction).
+_EQUATORIAL_POINTING_FRAMES = frozenset({"J2000", "ICRS"})
+
+
+def _pointing_direction_frame(ms):
+    """Measure reference of ``POINTING.DIRECTION`` (upper-case), or ``""`` if unavailable.
+
+    Reads the column's ``MEASINFO``/``Ref`` keyword via casacore. A missing table or keyword
+    yields ``""`` (treated as equatorial by the caller, preserving the legacy fast path).
+    """
+    try:
+        from casacore.tables import table
+
+        with table(f"{ms}::POINTING", ack=False) as tab:
+            measinfo = tab.getcolkeywords("DIRECTION").get("MEASINFO", {})
+        return str(measinfo.get("Ref", "")).upper()
+    except Exception:
+        return ""
+
+
 def read_pointing_centre(ms, fallback_ra0, fallback_dec0):
     """Antenna pointing centre (radians) from ``POINTING.DIRECTION``.
 
     This is where the dishes point, and hence where the primary beam is centred -- distinct
     from ``FIELD.PHASE_DIR`` (the correlator phase centre, a freely-shiftable quantity). Reads
-    the poly order-0 term of the first row's direction (J2000 RA/Dec) and falls back to the
-    given phase centre, with a warning, when the MS has no usable POINTING table.
+    the poly order-0 term of the first row's direction and falls back to the given phase
+    centre, with a warning, when the MS has no usable POINTING table.
+
+    The direction is interpreted as a fixed sky position, which requires an equatorial measure
+    frame. ``J2000``/``ICRS`` (and an absent keyword, as older simms MSs may have) take the
+    fast path silently; another equatorial frame is accepted with a warning; a **horizontal**
+    frame (``AZEL`` etc.) raises :class:`NotImplementedError`, since it maps to a
+    time-dependent sky direction that a single beam centre cannot represent.
     """
     from daskms import xds_from_table
+
+    frame = _pointing_direction_frame(ms)
+    if frame in _HORIZONTAL_POINTING_FRAMES:
+        raise NotImplementedError(
+            f"POINTING.DIRECTION is in the horizontal frame {frame!r}, which maps to a "
+            f"time-dependent sky position; a fixed primary-beam centre is unsupported. Supply "
+            f"a J2000/ICRS POINTING table or a target-tracking MS."
+        )
+    if frame and frame not in _EQUATORIAL_POINTING_FRAMES:
+        log.warning(
+            "POINTING.DIRECTION frame %r is treated as a fixed RA/Dec beam centre; if it is "
+            "not equatorial the primary beam may be mis-centred.",
+            frame,
+        )
 
     try:
         pnt = xds_from_table(f"{ms}::POINTING")[0]

--- a/tests/beam_tests.py
+++ b/tests/beam_tests.py
@@ -764,3 +764,68 @@ def test_full_jones_circular_equals_S_Vlin_SH():
     vc = predict_block(circ, uvw, times=times, antenna1=a1, antenna2=a2)[0, 0].reshape(2, 2)
     S = corr_basis_transform(True)
     np.testing.assert_allclose(vc, S @ vl @ S.conj().T, atol=1e-5)
+
+
+# --- POINTING.DIRECTION measure frame (#144) -------------------------------------
+
+import os  # noqa: E402
+
+from simms.skymodel.beams import read_pointing_centre  # noqa: E402
+
+from . import InitTest  # noqa: E402
+
+
+def _write_pointing_ms(base_dir, ra, dec, ref):
+    """A minimal MS whose ``POINTING.DIRECTION`` carries the given measure ``Ref``.
+
+    ``ref=None`` omits the MEASINFO keyword entirely (as older MSs may).
+    """
+    from casacore.tables import makearrcoldesc, maketabdesc, table
+
+    ms = os.path.join(base_dir, "pnt.ms")
+    pnt = os.path.join(ms, "POINTING")
+    mt = table(ms, maketabdesc([makearrcoldesc("DUMMY", 0.0)]), nrow=1, ack=False)
+    pt = table(pnt, maketabdesc([makearrcoldesc("DIRECTION", 0.0, ndim=2)]), nrow=1, ack=False)
+    pt.putcell("DIRECTION", 0, np.array([[ra, dec]], dtype=float))  # (npoly=1, radec=2)
+    if ref is not None:
+        pt.putcolkeyword("DIRECTION", "MEASINFO", {"type": "direction", "Ref": ref})
+    pt.flush()
+    pt.close()
+    mt.putkeyword("POINTING", f"Table: {pnt}")
+    mt.flush()
+    mt.close()
+    return ms
+
+
+def test_read_pointing_centre_j2000_fast_path():
+    pytest.importorskip("casacore")
+    it = InitTest()
+    ms = _write_pointing_ms(it.random_named_directory(), 0.5, -0.7, "J2000")
+    assert read_pointing_centre(ms, 1.0, 1.0) == pytest.approx((0.5, -0.7))
+
+
+def test_read_pointing_centre_missing_measinfo_falls_through():
+    # An absent MEASINFO keyword is treated as equatorial (legacy behaviour): the stored
+    # direction is returned rather than the phase-centre fallback.
+    pytest.importorskip("casacore")
+    it = InitTest()
+    ms = _write_pointing_ms(it.random_named_directory(), 0.3, -0.4, None)
+    assert read_pointing_centre(ms, 1.0, 1.0) == pytest.approx((0.3, -0.4))
+
+
+def test_read_pointing_centre_rejects_azel():
+    pytest.importorskip("casacore")
+    it = InitTest()
+    ms = _write_pointing_ms(it.random_named_directory(), 0.5, -0.7, "AZEL")
+    with pytest.raises(NotImplementedError, match="AZEL"):
+        read_pointing_centre(ms, 1.0, 1.0)
+
+
+def test_read_pointing_centre_warns_on_nonstandard_equatorial(caplog):
+    pytest.importorskip("casacore")
+    it = InitTest()
+    ms = _write_pointing_ms(it.random_named_directory(), 0.5, -0.7, "B1950")
+    with caplog.at_level("WARNING", logger="simms.skysim"):
+        centre = read_pointing_centre(ms, 1.0, 1.0)
+    assert centre == pytest.approx((0.5, -0.7))
+    assert any("B1950" in r.message for r in caplog.records)


### PR DESCRIPTION
Follow-up from #143 (centre the primary beam on `POINTING.DIRECTION`). Closes #144.

`read_pointing_centre` read `POINTING.DIRECTION[0,0]` as a fixed J2000 RA/Dec without
inspecting the column's measure frame. That holds for simms-made MSs and conventional
target-tracking observations, but is **wrong for an AZEL (horizontal) frame**: an az/el
pair maps to a *time-dependent* sky direction, so a single constant beam centre silently
mis-centres the primary beam.

### Change
- Read the `DIRECTION` `MEASINFO`/`Ref` keyword via casacore (`_pointing_direction_frame`).
- `J2000`/`ICRS` — and an **absent** keyword, as older MSs may have — take the current fast
  path silently (backward compatible; verified simms writes `Ref: J2000`).
- Any other **equatorial** frame is accepted with a warning.
- A **horizontal** frame (`AZEL`, `AZELGEO`, `AZELSW`, `AZELNE`, `HADEC`) raises
  `NotImplementedError` with a clear message instead of returning a bogus centre.
- Full per-timestamp AZEL→RADEC conversion is deferred deliberately — it would break the
  fixed-centre assumption throughout the beam path (issue scope note).

### Tests
`tests/beam_tests.py` builds a minimal MS with a chosen `DIRECTION` MEASINFO: J2000 →
returns the stored RA/Dec; missing MEASINFO → returns it (legacy fallback); `AZEL` →
raises; a non-standard equatorial frame → warns but returns. Full beam suite +
`predict_beam_e2e_tests.py` (real J2000 MSs) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
