### PR TITLE
Fix sexagesimal ra/dec joins and add --source-schema to primary-beam apply/correct

### DIFF
--- a/src/simms/apps/simms-cabs.yaml
+++ b/src/simms/apps/simms-cabs.yaml
@@ -371,6 +371,15 @@ cabs:
         info: Input ASCII component sky model (apply/correct).
         dtype: File
         abbreviation: ascii
+      ascii-delimiter:
+        info: Delimiter used in the ascii-sky file. Defaults to whitespace.
+        dtype: str
+        abbreviation: ad
+      source-schema:
+        info: Custom source schema (YAML) mapping the ascii-sky columns to the fields simms expects,
+              as for skysim. Defaults to the built-in simms source schema.
+        dtype: File
+        required: no
       output:
         info: Output path - FITS beam (to-fits) or beamed/corrected sky model (apply/correct).
         dtype: str

--- a/src/simms/schemas/source_schema.yaml
+++ b/src/simms/schemas/source_schema.yaml
@@ -15,21 +15,24 @@ parameters:
     units: deg
     ptype: longitude
     join: [ra_h, ra_m, ra_s]
+  # The h/m/s and d/m/s fields below are sexagesimal components of ra and dec.
+  # They are plain numbers; the units of the leading component (ra_h, dec_d)
+  # set the scale of the joined sexagesimal value.
   ra_h:
-    info: Right ascension
+    info: Right ascension hours (sexagesimal component)
     alias: null
-    units: hour
-    ptype: longitude
+    units: hourangle
+    ptype: number
   ra_m:
-    info: Right ascension
+    info: Right ascension minutes (sexagesimal component)
     alias: null
-    units: min
-    ptype: longitude
+    units: null
+    ptype: number
   ra_s:
-    info: Right ascension
+    info: Right ascension seconds (sexagesimal component)
     alias: null
-    units: sec
-    ptype: longitude
+    units: null
+    ptype: number
   dec:
     info: Declination
     alias: null
@@ -37,20 +40,20 @@ parameters:
     ptype: latitude
     join: [dec_d, dec_m, dec_s]
   dec_d:
-    info: Right ascension
+    info: Declination degrees (sexagesimal component)
     alias: null
     units: deg
-    ptype: longitude
+    ptype: number
   dec_m:
-    info: Right ascension
+    info: Declination arcminutes (sexagesimal component)
     alias: null
-    units: arcmin
-    ptype: longitude
+    units: null
+    ptype: number
   dec_s:
-    info: Right ascension
+    info: Declination arcseconds (sexagesimal component)
     alias: null
-    units: arcsec
-    ptype: longitude
+    units: null
+    ptype: number
   stokes_i: 
     info: Stokes I
     alias: null

--- a/src/simms/skymodel/ascii_skies.py
+++ b/src/simms/skymodel/ascii_skies.py
@@ -106,6 +106,7 @@ class ASCIISource:
     def __post_init__(self):
         self.parameters = self.schema.parameters
         self.existing_fields = []
+        self.raw_values = {}
         self.is_finalised = False
 
     def set_source_param(self, field: str, value: str | float | int):
@@ -137,6 +138,10 @@ class ASCIISource:
         param = getattr(self.parameters, field)
         param.set_value(value)
         setattr(self, field, param.value)
+        # Joined fields (e.g. dec from dec_d/dec_m/dec_s) are re-parsed from the
+        # original strings in finalise(), because the sign is lost once "-00" is
+        # converted to 0.0.
+        self.raw_values[field] = value
         self.existing_fields.append(field)
 
     def alias_to_field_mapper(self):
@@ -184,7 +189,23 @@ class ASCIISource:
         for field, param in self.parameters.items():
             if getattr(param, "join", []) and field not in fields:
                 join_us = param.join
-                joined = np.sum([getattr(self, key, 0) for key in join_us])
+                if not any(key in fields for key in join_us):
+                    continue
+                # Join the components as one sexagesimal string so the sign of the
+                # leading component applies to the minutes/seconds too: summing the
+                # already-converted values gives -65 + 45' = -64.25 deg instead of
+                # -65.75 deg, and a "-00" degree field loses its sign entirely.
+                sexagesimal = ":".join(str(self.raw_values.get(key, 0)) for key in join_us)
+                # The leading component's units set the sexagesimal scale
+                # (hourangle for h:m:s of RA, deg for d:m:s of declination).
+                scale_units = getattr(self.parameters, join_us[0]).units or param.units
+                ptype_coord, target_units, _ = PTYPE_MAPPER[param.ptype]
+                try:
+                    joined = ptype_coord(sexagesimal, unit=scale_units).to(target_units).value
+                except ValueError as exc:
+                    raise ASCIISourceError(
+                        f"Cannot parse field '{field}' from its components {join_us} (joined as '{sexagesimal}'): {exc}"
+                    )
                 setattr(self, field, joined)
 
     def value_or_default(self, field: str) -> int | float | str:
@@ -373,11 +394,12 @@ class ASCIISkymodel:
                 # skip lines that are commented
                 if line.startswith("#"):
                     continue
-                rowdata = line.strip().split(self.delimiter)
-                # skip empty lines
-                if len(rowdata) == 0:
+                # skip empty lines before splitting: "".split(",") is [""], not [],
+                # so a blank line in a delimited file would fail the column count
+                if not line.strip():
                     continue
-                elif len(rowdata) != len(header):
+                rowdata = line.strip().split(self.delimiter)
+                if len(rowdata) != len(header):
                     # plus 2 because header line is not counted (+1), and python starts counting at 0 (+1)
                     raise ASCIISkymodelError(
                         f"The number of columns in row {counter + 2} rows does not match the number of"

--- a/src/simms/skymodel/pb_ops.py
+++ b/src/simms/skymodel/pb_ops.py
@@ -217,12 +217,12 @@ def apply_correct_image(opts, invert):
 
 def apply_correct_ascii(opts, invert):
     """Scale ASCII component fluxes by the averaged power beam (apply) or its inverse (correct)."""
-    from simms import SCHEMADIR
-    from simms.skymodel.ascii_skies import ASCIISkymodel
+    from simms.skymodel.ascii_skies import ASCIISkymodel, ASCIISource
     from simms.utilities import radec2lm
 
     obs = _observation(opts.ms, opts.field_id, opts.spw_id)
-    sky = ASCIISkymodel(opts.ascii_sky, source_schema_file=f"{SCHEMADIR}/source_schema.yaml")
+    # ASCIISkymodel falls back to the built-in source schema when source_schema is unset
+    sky = ASCIISkymodel(opts.ascii_sky, delimiter=opts.ascii_delimiter, source_schema_file=opts.source_schema)
     lm = np.array([radec2lm(obs["ra0"], obs["dec0"], s.ra, s.dec) for s in sky.sources])
     ell, emm = (lm[:, 0], lm[:, 1]) if len(lm) else (np.array([]), np.array([]))
     A = _averaged_beam(provider_from(opts), ell, emm, obs["ra0"], obs["dec0"], obs, opts.beam_pa_step)
@@ -233,7 +233,11 @@ def apply_correct_ascii(opts, invert):
     # came from -- so we never re-implement the comment/blank-line skipping here.
     lines = open(opts.ascii_sky).read().splitlines()
     cols = lines[0].replace("#format:", "").strip().split(sky.delimiter)
-    stokes_idx = [cols.index(c) for c in ("stokes_i", "stokes_q", "stokes_u", "stokes_v") if c in cols]
+    # The header holds column aliases when a custom schema renames them; map each
+    # column back to its schema field before looking for the stokes columns.
+    alias_to_field = ASCIISource(sky.schema).alias_to_field_mapper()
+    fields_by_col = [alias_to_field.get(col, col) for col in cols]
+    stokes_idx = [i for i, f in enumerate(fields_by_col) if f in ("stokes_i", "stokes_q", "stokes_u", "stokes_v")]
 
     dropped = set()
     for src, source in enumerate(sky.sources):

--- a/src/simms/utilities.py
+++ b/src/simms/utilities.py
@@ -138,7 +138,7 @@ def quantity_to_value(
             try:
                 quant_value = value * getattr(units, val_units)
             except AttributeError:
-                raise SkymodelSchemaError("Unknown parameter units '{val_units}'")
+                raise SkymodelSchemaError(f"Unknown parameter units '{val_units}'")
         else:
             quant_value = units.Quantity(value)
     elif is_numeric(value):

--- a/tests/ascii_sky_tests.py
+++ b/tests/ascii_sky_tests.py
@@ -1,6 +1,7 @@
 import math
 import os
 
+import numpy as np
 import pytest
 from astropy.coordinates import Angle, Latitude, Longitude
 from omegaconf import OmegaConf
@@ -43,13 +44,15 @@ def load_default_schema() -> ASCIISourceSchema:
     return schema
 
 
-def source_type_validation_test():
-    src = SourceType(requires=["ra", "dec", "a|b|c", "e|f"])
+def test_source_type_validation():
+    src = SourceType("Test Source", required=["ra", "dec", "a|b|c", "e|f"])
     with pytest.raises(ASCIISourceError):
         src.is_valid(["ra", "dec", "a"], raise_exception=True)
 
+    # 'a' satisfies 'a|b|c' but nothing satisfies 'e|f'
     assert not src.is_valid(["ra", "dec", "a"])
     assert src.is_valid(["ra", "dec", "a", "e"])
+    assert not src.is_valid(["dec", "a", "e"])
 
 
 def test_set_source_param_conversions():
@@ -73,10 +76,12 @@ def test_alias_mapper():
     src = ASCIISource(schema)
 
     a2f = src.alias_to_field_mapper()
+    f2a = src.field_to_alias_mapper()
 
-    # Default schema has no aliases set, so mapping is identity
+    # Default schema has no aliases set, so mapping is identity both ways
     for key in ["ra", "dec", "stokes_i", "name"]:
         assert a2f[key] == key
+        assert f2a[key] == key
 
 
 def test_finalise_point_vs_extended_and_polarisation():
@@ -264,3 +269,167 @@ def test_skymodel_parsing_csv_with_alias(params):
     assert pytest.approx(s1.dec, abs=1e-12) == Latitude("-45 deg").to("rad").value
     assert pytest.approx(s1.stokes_i, abs=1e-12) == 0.5
     assert s1.name == "S1"
+
+
+SEXAGESIMAL_HEADER = "#format: name ra_h ra_m ra_s dec_d dec_m dec_s stokes_i"
+
+
+def parse_single_source(params, content: str, **kwargs):
+    model = ASCIISkymodel(params.write_temp_file(content), **kwargs)
+    assert len(model.sources) == 1
+    return model.sources[0]
+
+
+def test_sexagesimal_join_negative_dec(params):
+    # Regression: the sign of dec_d must apply to the arcmin/arcsec components
+    # too. The naive sum gave -65 + 45' + 9.08'' = -64.2475 deg for PKS0407-65.
+    src = parse_single_source(params, f"{SEXAGESIMAL_HEADER}\nPKS0407-65 4 8 20.38 -65 45 9.08 15.0\n")
+    assert pytest.approx(math.degrees(src.dec), abs=1e-9) == -(65 + 45 / 60 + 9.08 / 3600)
+    # Regression: ra_m/ra_s are minutes/seconds of time (15 arcmin/arcsec each),
+    # not arcmin/arcsec.
+    assert pytest.approx(math.degrees(src.ra), abs=1e-9) == (4 + 8 / 60 + 20.38 / 3600) * 15
+
+
+def test_sexagesimal_join_minus_zero_degrees(params):
+    # Declinations between 0 and -1 deg have dec_d == "-00"; the sign must
+    # survive even though the degrees component parses to 0.0.
+    src = parse_single_source(params, f"{SEXAGESIMAL_HEADER}\nJ0000-0045 0 0 0 -00 45 9.08 1.0\n")
+    assert pytest.approx(math.degrees(src.dec), abs=1e-9) == -(45 / 60 + 9.08 / 3600)
+
+
+def test_sexagesimal_join_positive(params):
+    src = parse_single_source(params, f"{SEXAGESIMAL_HEADER}\nSrc 12 30 0 30 30 30 1.0\n")
+    assert pytest.approx(math.degrees(src.ra), abs=1e-9) == 187.5
+    assert pytest.approx(math.degrees(src.dec), abs=1e-9) == 30 + 30 / 60 + 30 / 3600
+
+
+def test_sexagesimal_join_partial_components(params):
+    # Only some components in the header: the missing ones default to 0
+    src = parse_single_source(params, "#format: ra_h dec_d stokes_i\n6 -30 1.0\n")
+    assert pytest.approx(math.degrees(src.ra), abs=1e-9) == 90.0
+    assert pytest.approx(math.degrees(src.dec), abs=1e-9) == -30.0
+
+
+def test_direct_field_wins_over_join(params):
+    # If ra/dec are given directly, the sexagesimal components are ignored
+    src = parse_single_source(params, "#format: ra dec dec_d dec_m stokes_i\n10 -10 -65 45 1.0\n")
+    assert pytest.approx(math.degrees(src.dec), abs=1e-9) == -10.0
+
+
+def test_join_out_of_range_dec_rejected(params):
+    with pytest.raises(ASCIISourceError, match="dec"):
+        parse_single_source(params, f"{SEXAGESIMAL_HEADER}\nBad 0 0 0 -95 0 0 1.0\n")
+
+
+def test_join_signed_minutes_rejected(params):
+    # The sign belongs on the leading component only; signed arcminutes are
+    # ambiguous and must be a clear error, not a silently wrong coordinate
+    with pytest.raises(ASCIISourceError, match="dec"):
+        parse_single_source(params, f"{SEXAGESIMAL_HEADER}\nBad 0 0 0 -65 -45 -9.08 1.0\n")
+
+
+def test_join_backward_compat_old_component_schema(params):
+    # Custom user schemas copied from the old default declare the components
+    # with units hour/min/sec and ptype longitude; joins must still be correct
+    schema_yaml = "\n".join(
+        [
+            "info: Old-style schema",
+            "parameters:",
+            "  name: {info: Name, units: null, ptype: string}",
+            "  ra: {info: RA, units: deg, ptype: longitude, join: [ra_h, ra_m, ra_s]}",
+            "  ra_h: {info: RA, units: hour, ptype: longitude}",
+            "  ra_m: {info: RA, units: min, ptype: longitude}",
+            "  ra_s: {info: RA, units: sec, ptype: longitude}",
+            "  dec: {info: Dec, units: deg, ptype: latitude, join: [dec_d, dec_m, dec_s]}",
+            "  dec_d: {info: Dec, units: deg, ptype: longitude}",
+            "  dec_m: {info: Dec, units: arcmin, ptype: longitude}",
+            "  dec_s: {info: Dec, units: arcsec, ptype: longitude}",
+            "  stokes_i: {info: Stokes I, units: Jy, ptype: flux, required: true}",
+        ]
+    )
+    schema_path = params.write_temp_file(schema_yaml, suffix=".yaml")
+    src = parse_single_source(
+        params,
+        f"{SEXAGESIMAL_HEADER}\nPKS0407-65 4 8 20.38 -65 45 9.08 15.0\n",
+        source_schema_file=schema_path,
+    )
+    assert pytest.approx(math.degrees(src.dec), abs=1e-9) == -(65 + 45 / 60 + 9.08 / 3600)
+    assert pytest.approx(math.degrees(src.ra), abs=1e-9) == (4 + 8 / 60 + 20.38 / 3600) * 15
+
+
+def test_blank_and_comment_lines_skipped_and_lineno_tracked(params):
+    content = "\n".join(
+        [
+            "#format: ra,dec,stokes_i,name",
+            "0,0,1.0,S0",
+            "",
+            "# a comment",
+            "45,-45,0.5,S1",
+            "",
+        ]
+    )
+    model = ASCIISkymodel(params.write_temp_file(content, suffix=".csv"), delimiter=",")
+    assert len(model.sources) == 2
+    assert [src.name for src in model.sources] == ["S0", "S1"]
+    # lineno maps a parsed source back to its line in the file (header is line 0)
+    assert [src.lineno for src in model.sources] == [1, 4]
+
+
+def test_value_or_default():
+    schema = load_default_schema()
+    src = ASCIISource(schema)
+    src.set_source_param("stokes_i", "2.0")
+
+    # a set field returns its value; unset fields fall back to the schema null value
+    assert src.value_or_default("stokes_i") == pytest.approx(2.0)
+    assert src.value_or_default("pa") == 0  # angle fields default to 0
+    assert src.value_or_default("cont_reffreq") is None  # frequency fields have no default
+
+
+def test_continuum_coefficients_truncation():
+    schema = load_default_schema()
+
+    src = ASCIISource(schema)
+    src.set_source_param("cont_coeff_1", "-0.7")
+    assert src.continuum_coefficients() == pytest.approx([-0.7])
+
+    # unset coefficient between set ones is zero-filled, trailing ones dropped
+    src2 = ASCIISource(schema)
+    src2.set_source_param("cont_coeff_1", "-0.7")
+    src2.set_source_param("cont_coeff_3", "0.1")
+    assert src2.continuum_coefficients() == pytest.approx([-0.7, 0.0, 0.1])
+
+    src3 = ASCIISource(schema)
+    assert src3.continuum_coefficients() == []
+
+
+def test_transient_brightness_matrix_time_axis():
+    schema = load_default_schema()
+    src = ASCIISource(schema)
+    for k, v in {
+        "ra": 0,
+        "dec": 0,
+        "stokes_i": 1.0,
+        "transient_start": "100 s",
+        "transient_period": "500 s",
+        "transient_ingress": "50 s",
+        "transient_absorb": 0.5,
+    }.items():
+        src.set_source_param(k, v)
+    src.finalise()
+    assert src.is_transient is True
+
+    freqs = [1.0e9, 1.1e9, 1.2e9]
+    unique_times = 1e9 + 60.0 * np.arange(20)
+    bmatrix = src.get_brightness_matrix(freqs, ncorr=4, unique_times=unique_times)
+    # transient sources get a time axis: (ncorr, ntime, nchan)
+    assert bmatrix.shape == (4, 20, 3)
+    # flux dips by transient_absorb mid-transit relative to out-of-transit
+    out_of_transit = bmatrix[0, 0, 0].real
+    mid_transit = bmatrix[0, :, 0].real.min()
+    assert pytest.approx(mid_transit / out_of_transit, abs=0.05) == 0.5
+
+    # a mapper expands unique times onto arbitrary output rows
+    mapper = [0, 0, 5, 19]
+    bmatrix_mapped = src.get_brightness_matrix(freqs, ncorr=4, unique_times=unique_times, time_index_mapper=mapper)
+    assert bmatrix_mapped.shape == (4, 4, 3)

--- a/tests/kernels_tests.py
+++ b/tests/kernels_tests.py
@@ -1,0 +1,116 @@
+"""Direct tests of the numba visibility-prediction kernels against a naive DFT.
+
+The kernels are the numerical core of skysim but are otherwise only exercised
+end-to-end; these tests pin their maths to an independent numpy reference.
+"""
+
+import numpy as np
+import pytest
+
+from simms.constants import C
+from simms.skymodel.kernels import RENORM_INTERVAL, is_uniform_grid, predict_vis
+
+RNG = np.random.default_rng(42)
+
+
+def reference_predict(uvw, freqs, lmn, gauss_shape, is_gauss, bmat, lightcurve, time_index):
+    """Naive per-row, per-source DFT implementing the documented kernel maths."""
+    nrow = uvw.shape[0]
+    nchan = freqs.size
+    nspec = bmat.shape[1]
+    vis = np.zeros((nrow, nchan, nspec), dtype=np.complex128)
+    for r in range(nrow):
+        u, v, _ = uvw[r]
+        for s in range(lmn.shape[0]):
+            amp = lightcurve[s, time_index[r]]
+            base = (uvw[r] @ lmn[s]) * 2.0 * np.pi / C
+            phasor = amp * np.exp(1j * base * freqs)
+            if is_gauss[s]:
+                ell, emm, ecc = gauss_shape[s]
+                fu1 = (u * emm - v * ell) * ecc
+                fv1 = u * ell + v * emm
+                phasor = phasor * np.exp(-(fu1**2 + fv1**2) * (freqs / C) ** 2)
+            vis[r] += bmat[s].T * phasor[:, None]
+    return vis
+
+
+def make_inputs(nrow=6, nchan=8, nsrc=3, nspec=4, ntime=1, gauss=False, uniform=True):
+    uvw = RNG.uniform(-2e3, 2e3, size=(nrow, 3))
+    if uniform:
+        freqs = np.linspace(1.0e9, 1.5e9, nchan)
+    else:
+        freqs = np.sort(RNG.uniform(1.0e9, 1.5e9, size=nchan))
+    # small direction cosines; third component is n - 1
+    lm = RNG.uniform(-0.01, 0.01, size=(nsrc, 2))
+    n_minus_1 = np.sqrt(1.0 - (lm**2).sum(axis=1)) - 1.0
+    lmn = np.column_stack([lm, n_minus_1])
+    gauss_shape = RNG.uniform(1e-5, 1e-4, size=(nsrc, 3)) if gauss else np.zeros((nsrc, 3))
+    is_gauss = np.full(nsrc, gauss)
+    bmat = RNG.normal(size=(nsrc, nspec, nchan)) + 1j * RNG.normal(size=(nsrc, nspec, nchan))
+    lightcurve = np.ones((nsrc, ntime)) if ntime == 1 else RNG.uniform(0.2, 1.0, size=(nsrc, ntime))
+    time_index = np.zeros(nrow, dtype=np.int64) if ntime == 1 else RNG.integers(0, ntime, size=nrow)
+    return uvw, freqs, lmn, gauss_shape, is_gauss, bmat, lightcurve, time_index
+
+
+def run_kernel(inputs, uniform):
+    uvw, freqs, lmn, gauss_shape, is_gauss, bmat, lightcurve, time_index = inputs
+    vis = np.zeros((uvw.shape[0], freqs.size, bmat.shape[1]), dtype=np.complex128)
+    predict_vis(uvw, freqs, uniform, lmn, gauss_shape, is_gauss, bmat, lightcurve, time_index, vis)
+    return vis
+
+
+@pytest.mark.parametrize("uniform", [True, False])
+def test_predict_vis_points_match_reference(uniform):
+    inputs = make_inputs(uniform=uniform)
+    vis = run_kernel(inputs, uniform=uniform)
+    np.testing.assert_allclose(vis, reference_predict(*inputs), rtol=1e-9, atol=1e-12)
+
+
+def test_predict_vis_uniform_recurrence_across_renorm():
+    # The uniform-grid path replaces per-channel sincos with a phasor
+    # recurrence that is renormalised every RENORM_INTERVAL channels; span
+    # several intervals so drift and the renorm step are both exercised.
+    inputs = make_inputs(nchan=3 * RENORM_INTERVAL + 7)
+    vis = run_kernel(inputs, uniform=True)
+    np.testing.assert_allclose(vis, reference_predict(*inputs), rtol=1e-8, atol=1e-10)
+
+
+def test_predict_vis_gaussian_matches_reference():
+    inputs = make_inputs(gauss=True)
+    vis = run_kernel(inputs, uniform=True)
+    np.testing.assert_allclose(vis, reference_predict(*inputs), rtol=1e-9, atol=1e-12)
+
+
+def test_predict_vis_mixed_point_and_gaussian():
+    inputs = list(make_inputs(nsrc=4, gauss=True))
+    is_gauss = inputs[4]
+    is_gauss[:2] = False
+    vis = run_kernel(tuple(inputs), uniform=True)
+    np.testing.assert_allclose(vis, reference_predict(*inputs), rtol=1e-9, atol=1e-12)
+
+
+def test_predict_vis_lightcurve_scaling():
+    inputs = make_inputs(ntime=5)
+    vis = run_kernel(inputs, uniform=True)
+    np.testing.assert_allclose(vis, reference_predict(*inputs), rtol=1e-9, atol=1e-12)
+
+
+def test_predict_vis_accumulates_into_buffer():
+    inputs = make_inputs()
+    uvw, freqs, lmn, gauss_shape, is_gauss, bmat, lightcurve, time_index = inputs
+    vis = np.zeros((uvw.shape[0], freqs.size, bmat.shape[1]), dtype=np.complex128)
+    predict_vis(uvw, freqs, True, lmn, gauss_shape, is_gauss, bmat, lightcurve, time_index, vis)
+    once = vis.copy()
+    predict_vis(uvw, freqs, True, lmn, gauss_shape, is_gauss, bmat, lightcurve, time_index, vis)
+    np.testing.assert_allclose(vis, 2 * once, rtol=1e-12)
+
+
+def test_is_uniform_grid():
+    assert is_uniform_grid(np.linspace(1e9, 2e9, 64))
+    assert is_uniform_grid(np.array([1e9]))
+    assert is_uniform_grid(np.array([1e9, 1.1e9]))
+    jittered = np.linspace(1e9, 2e9, 64)
+    jittered[10] += 1e5
+    assert not is_uniform_grid(jittered)
+    # descending but uniform spacing is still a uniform grid
+    assert is_uniform_grid(np.linspace(2e9, 1e9, 64))

--- a/tests/primary_beam_tests.py
+++ b/tests/primary_beam_tests.py
@@ -26,6 +26,8 @@ def _opts(mode, **over):
         "ms": None,
         "fits_sky": None,
         "ascii_sky": None,
+        "ascii_delimiter": None,
+        "source_schema": None,
         "output": None,
         "telescope_name_column": "TELESCOPE_NAME",
         "label": None,
@@ -235,12 +237,53 @@ def test_apply_then_correct_ascii_is_identity(fx):
     assert rec_flux["B"] == pytest.approx(3.0, rel=1e-3)
 
 
-def _read_ascii_flux(path):
+def _read_ascii_flux(path, delimiter=None):
     flux = {}
     for ln in open(path):
         s = ln.strip()
         if not s or s.startswith("#"):
             continue
-        f = s.split()
+        f = s.split(delimiter)
         flux[f[0]] = float(f[3])  # name ra dec stokes_i
     return flux
+
+
+def test_apply_then_correct_ascii_custom_schema(fx):
+    # A CSV sky model whose columns are renamed via a custom source schema;
+    # apply/correct must honour --source-schema and --ascii-delimiter, and find
+    # the flux column through its alias.
+    schema_yaml = "\n".join(
+        [
+            "info: Aliased schema",
+            "parameters:",
+            "  name: {info: Name, alias: NAME, units: null, ptype: string}",
+            "  ra: {info: RA, alias: RA, units: deg, ptype: longitude, required: true}",
+            "  dec: {info: Dec, alias: DEC, units: deg, ptype: latitude, required: true}",
+            "  stokes_i: {info: Stokes I, alias: I, units: Jy, ptype: flux, required: true}",
+        ]
+    )
+    schema = fx.random_named_file(suffix=".yaml")
+    with open(schema, "w") as fh:
+        fh.write(schema_yaml + "\n")
+
+    sky = fx.random_named_file(suffix=".csv")
+    with open(sky, "w") as fh:
+        fh.write("#format: NAME,RA,DEC,I\n")
+        fh.write("A,15.0,-31.0,5.0\n")  # at phase centre (1h0m0s -31d)
+        fh.write("B,15.0,-31.5,3.0\n")  # ~0.5 deg off
+
+    apparent = fx.random_named_file(suffix=".csv")
+    primary_beam.runit(
+        _opts("apply", ms=fx.ms, ascii_sky=sky, ascii_delimiter=",", source_schema=schema, output=apparent)
+    )
+    app_flux = _read_ascii_flux(apparent, delimiter=",")
+    assert app_flux["A"] == pytest.approx(5.0, rel=1e-3)  # on-axis ~unattenuated
+    assert app_flux["B"] < 3.0  # off-axis attenuated
+
+    recovered = fx.random_named_file(suffix=".csv")
+    primary_beam.runit(
+        _opts("correct", ms=fx.ms, ascii_sky=apparent, ascii_delimiter=",", source_schema=schema, output=recovered)
+    )
+    rec_flux = _read_ascii_flux(recovered, delimiter=",")
+    assert rec_flux["A"] == pytest.approx(5.0, rel=1e-3)
+    assert rec_flux["B"] == pytest.approx(3.0, rel=1e-3)

--- a/tests/utilities_tests.py
+++ b/tests/utilities_tests.py
@@ -1,0 +1,110 @@
+"""Tests for simms.utilities helpers, in particular quantity_to_value, which
+backs every schema-driven unit conversion in the ASCII sky model reader."""
+
+import math
+
+import numpy as np
+import pytest
+from astropy import units
+from astropy.coordinates import Angle, Latitude, Longitude
+
+from simms.exceptions import SkymodelSchemaError
+from simms.utilities import (
+    get_noise,
+    is_numeric,
+    is_range_in_range,
+    quantity_to_value,
+    radec2lm,
+)
+
+
+def test_is_numeric():
+    assert is_numeric("1.5")
+    assert is_numeric("-65")
+    assert is_numeric("1e9")
+    assert is_numeric(3)
+    assert not is_numeric("4h30m")
+    assert not is_numeric(None)
+    assert not is_numeric("")
+
+
+def test_quantity_to_value_null():
+    assert quantity_to_value(Angle, None, null_value=0) == 0
+    assert quantity_to_value(Angle, "null", null_value=None) is None
+
+
+def test_quantity_to_value_numeric_with_units():
+    # plain numbers are scaled by the schema units and converted to the target
+    assert quantity_to_value(Angle, 180, "deg", target_units="rad") == pytest.approx(math.pi)
+    assert quantity_to_value(Angle, "180", "deg", target_units="rad") == pytest.approx(math.pi)
+    assert quantity_to_value(units.Quantity, 2.0, "GHz", target_units="Hz") == pytest.approx(2e9)
+
+
+def test_quantity_to_value_numeric_without_units():
+    assert quantity_to_value(units.Quantity, "8") == pytest.approx(8.0)
+    assert quantity_to_value(units.Quantity, 8) == pytest.approx(8.0)
+
+
+def test_quantity_to_value_string_with_units():
+    # strings that carry their own units bypass the schema units
+    assert quantity_to_value(Angle, "45 deg", target_units="rad") == pytest.approx(math.radians(45))
+    assert quantity_to_value(Longitude, "4h8m20.38s", target_units="rad") == pytest.approx(
+        math.radians((4 + 8 / 60 + 20.38 / 3600) * 15)
+    )
+    assert quantity_to_value(Latitude, "-65d45m9.08s", target_units="rad") == pytest.approx(
+        math.radians(-(65 + 45 / 60 + 9.08 / 3600))
+    )
+
+
+def test_quantity_to_value_string_passthrough():
+    assert quantity_to_value(str, "SrcA") == "SrcA"
+
+
+def test_quantity_to_value_unknown_units():
+    with pytest.raises(SkymodelSchemaError, match="parsecs_per_fortnight"):
+        quantity_to_value(Angle, 1.0, "parsecs_per_fortnight")
+
+
+def test_get_noise_scalar():
+    assert get_noise(400.0, 8, 1e6) == pytest.approx(400.0 / math.sqrt(2 * 1e6 * 8))
+
+
+def test_get_noise_per_baseline():
+    sefds = [400.0, 500.0, 600.0]
+    dtime, dfreq = 8, 1e6
+    noises = get_noise(sefds, dtime, dfreq)
+    # one noise per baseline pair, ordered as combinations(sefds, 2)
+    expected = [
+        math.sqrt(400.0 * 500.0 / (2 * dfreq * dtime)),
+        math.sqrt(400.0 * 600.0 / (2 * dfreq * dtime)),
+        math.sqrt(500.0 * 600.0 / (2 * dfreq * dtime)),
+    ]
+    assert noises == pytest.approx(expected)
+
+
+def test_is_range_in_range():
+    assert is_range_in_range((2, 3), (1, 4))
+    assert not is_range_in_range((0, 3), (1, 4))
+    assert is_range_in_range((1, 4), (1, 4))
+    # reversed tuples are normalised before comparison
+    assert is_range_in_range((3, 2), (4, 1))
+    assert not is_range_in_range((5, 2), (1, 4))
+
+
+def test_radec2lm():
+    # at the phase centre, (l, m) is (0, 0)
+    l_coord, m_coord = radec2lm(0.3, -0.5, 0.3, -0.5)
+    assert l_coord == pytest.approx(0.0)
+    assert m_coord == pytest.approx(0.0)
+
+    # with the phase centre on the equator at ra0=0: l = cos(dec) sin(ra), m = sin(dec)
+    ra = np.array([0.01, -0.02])
+    dec = np.array([0.03, -0.04])
+    l_coord, m_coord = radec2lm(0.0, 0.0, ra, dec)
+    np.testing.assert_allclose(l_coord, np.cos(dec) * np.sin(ra), rtol=1e-12)
+    np.testing.assert_allclose(m_coord, np.sin(dec), rtol=1e-12)
+
+    # pure declination offset from a general phase centre moves m only
+    l_coord, m_coord = radec2lm(1.0, 0.5, 1.0, 0.5 + 0.01)
+    assert l_coord == pytest.approx(0.0)
+    assert m_coord == pytest.approx(0.01, rel=1e-4)


### PR DESCRIPTION
Fixes two reported bugs in the ASCII sky-model path, plus issues found in the test audit the first bug prompted.

## Sexagesimal ra/dec joins were wrong three ways

`ASCIISource.finalise` built `ra`/`dec` from their sexagesimal components by summing the already-converted values, which broke:

- **Sign propagation**: for PKS0407-65 (`dec_d=-65, dec_m=45, dec_s=9.08`) the arcmin/arcsec added *toward* zero, giving −64.2475° instead of −65.7525°. Declinations between 0° and −1° (`dec_d="-00"`) lost their sign entirely.
- **Wrapping**: `dec_d` was declared `ptype: longitude`, so astropy `Longitude` wrapped −65° to 295° before the sum.
- **RA scale**: `ra_m`/`ra_s` had units `min`/`sec`, which astropy parses as arcmin/arcsec rather than minutes/seconds of time — every joined RA was wrong by up to 2°.

The join now re-parses the raw column strings as a single sexagesimal string (`"-65:45:9.08"`) through the joined field's own `Latitude`/`Longitude` type, with the scale (hourangle vs deg) taken from the leading component's units. That fixes all three in one place and adds range validation (dec = −95° is now a clear error instead of a silent wrap). Custom user schemas that copied the old component definitions still work (covered by a test).

## `primary-beam apply/correct` ignored custom schemas

The ASCII path hardcoded the built-in source schema and whitespace splitting. Added `--source-schema` and `--ascii-delimiter` (matching skysim). The flux scaling also looked up stokes columns by canonical name in the header, so an aliased flux column would have parsed fine but been **silently left unscaled** — the lookup now goes through the schema's alias-to-field mapper.

## Test audit fallout

- `source_type_validation_test` was never collected by pytest (wrong name pattern) and was broken besides — fixed and enabled.
- The numba `predict_vis` kernel — the numerical core of skysim — had no direct tests; added `tests/kernels_tests.py` validating it against a naive-DFT reference (point/gaussian/mixed sources, the uniform-grid phasor recurrence across its renormalisation boundary, lightcurve scaling, accumulation).
- `quantity_to_value` and friends were untested; added `tests/utilities_tests.py` (utilities.py 76% → 94%) and fixed a missing `f`-prefix that printed a literal `'{val_units}'` in its error message.
- Blank lines in *delimited* (CSV) sky models crashed the column-count check (`"".split(",") == [""]`); now skipped.

Suite: 196 → 229 passing; `ascii_skies.py` coverage 93% → 98%.

Known issue deliberately not touched here: spectral-line sources can never activate (`line_source` requires `line_ref_freq|line_redshift` but the schema defines `line_restfreq`), tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
