### PR TITLE
Apply code-review fixes to Cattery beam handling

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,9 +48,6 @@ include = [
     "/pyproject.toml",
 ]
 
-[tool.uv.sources]
-stimela-ninja = { git = "https://github.com/shinobi-dosho/stimela-ninja", branch = "main" }
-
 [tool.hatch.build.targets.wheel]
 packages = ["src/simms"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,9 @@ include = [
     "/pyproject.toml",
 ]
 
+[tool.uv.sources]
+stimela-ninja = { git = "https://github.com/shinobi-dosho/stimela-ninja", branch = "main" }
+
 [tool.hatch.build.targets.wheel]
 packages = ["src/simms"]
 

--- a/src/simms/apps/primary_beam.py
+++ b/src/simms/apps/primary_beam.py
@@ -61,6 +61,30 @@ def primary_beam(
     beam_pa_step: float = Field(
         1.0, description="Parallactic-angle sampling step (degrees) for the time-averaged beam."
     ),
+    fits_format: Literal["simms", "ddfacet"] = Field(
+        "simms",
+        description="to-fits output layout: simms's own single-file 4-plane HH/VV cube, or "
+        "DDFacet's 8-file per-Jones-element schema (--Beam-Model FITS).",
+        json_schema_extra={"abbreviation": "ff"},
+    ),
+    pol_basis: Literal["linear", "circular"] = Field(
+        "linear",
+        description="Correlation basis for the ddfacet fits-format output (xx/xy/yx/yy vs "
+        "rr/rl/lr/ll); must match the target MS's feed basis.",
+        json_schema_extra={"abbreviation": "pol"},
+    ),
+    beam_l_axis: Literal["-X", "X"] = Field(
+        "-X",
+        description="Sign convention for the ddfacet fits-format L axis, matching DDFacet's "
+        "--Beam-FITSLAxis (pass the same value to both).",
+        json_schema_extra={"abbreviation": "bla"},
+    ),
+    beam_m_axis: Literal["Y", "-Y"] = Field(
+        "Y",
+        description="Sign convention for the ddfacet fits-format M axis, matching DDFacet's "
+        "--Beam-FITSMAxis (pass the same value to both).",
+        json_schema_extra={"abbreviation": "bma"},
+    ),
     ms: str | None = Field(
         None,
         description="Measurement set (time/PA range, array position and frequencies). "
@@ -85,7 +109,8 @@ def primary_beam(
     ),
     output: str | None = Field(
         None,
-        description="Output path - FITS beam (to-fits) or beamed/corrected sky model (apply/correct).",
+        description="Output path - FITS beam (to-fits, or filename prefix when --fits-format ddfacet) "
+        "or beamed/corrected sky model (apply/correct).",
         json_schema_extra={"abbreviation": "o"},
     ),
     telescope_name_column: str = Field(

--- a/src/simms/apps/primary_beam.py
+++ b/src/simms/apps/primary_beam.py
@@ -61,27 +61,27 @@ def primary_beam(
     beam_pa_step: float = Field(
         1.0, description="Parallactic-angle sampling step (degrees) for the time-averaged beam."
     ),
-    fits_format: Literal["simms", "ddfacet"] = Field(
+    fits_format: Literal["simms", "cattery"] = Field(
         "simms",
         description="to-fits output layout: simms's own single-file 4-plane HH/VV cube, or "
-        "DDFacet's 8-file per-Jones-element schema (--Beam-Model FITS).",
+        "the Cattery/DDFacet 8-file per-Jones-element schema (--Beam-Model FITS).",
         json_schema_extra={"abbreviation": "ff"},
     ),
     pol_basis: Literal["linear", "circular"] = Field(
         "linear",
-        description="Correlation basis for the ddfacet fits-format output (xx/xy/yx/yy vs "
+        description="Correlation basis for the cattery fits-format output (xx/xy/yx/yy vs "
         "rr/rl/lr/ll); must match the target MS's feed basis.",
         json_schema_extra={"abbreviation": "pol"},
     ),
     beam_l_axis: Literal["-X", "X"] = Field(
         "-X",
-        description="Sign convention for the ddfacet fits-format L axis, matching DDFacet's "
+        description="Sign convention for the cattery fits-format L axis, matching DDFacet's "
         "--Beam-FITSLAxis (pass the same value to both).",
         json_schema_extra={"abbreviation": "bla"},
     ),
     beam_m_axis: Literal["Y", "-Y"] = Field(
         "Y",
-        description="Sign convention for the ddfacet fits-format M axis, matching DDFacet's "
+        description="Sign convention for the cattery fits-format M axis, matching DDFacet's "
         "--Beam-FITSMAxis (pass the same value to both).",
         json_schema_extra={"abbreviation": "bma"},
     ),
@@ -109,7 +109,7 @@ def primary_beam(
     ),
     output: str | None = Field(
         None,
-        description="Output path - FITS beam (to-fits, or filename prefix when --fits-format ddfacet) "
+        description="Output path - FITS beam (to-fits, or filename prefix when --fits-format cattery) "
         "or beamed/corrected sky model (apply/correct).",
         json_schema_extra={"abbreviation": "o"},
     ),

--- a/src/simms/apps/skysim.py
+++ b/src/simms/apps/skysim.py
@@ -67,11 +67,11 @@ class _BeamContext:
     def __init__(self, opts, ms, msds, ra0, dec0, ncorr):
         ant_ds = xds_from_table(f"{ms}::ANTENNA")[0]
         pol_ds = xds_from_table(f"{ms}::POLARIZATION")[0]
-        # A DDFacet heterogeneous-beam json types antennas by raw ANTENNA.NAME (its own
-        # convention, exact/regex/cmd::default); simms' own beam-config YAML instead groups
-        # by the TELESCOPE_NAME-column label. Detect which by the config file's extension.
-        is_ddfacet_json = str(opts.primary_beam).lower().endswith(".json")
-        if is_ddfacet_json:
+        # A Cattery/DDFacet heterogeneous-beam json types antennas by raw ANTENNA.NAME (its
+        # own convention, exact/regex/cmd::default); simms' own beam-config YAML instead
+        # groups by the TELESCOPE_NAME-column label. Detect which by the config file's extension.
+        is_cattery_json = str(opts.primary_beam).lower().endswith(".json")
+        if is_cattery_json:
             typing_col = "NAME"
         else:
             typing_col = opts.telescope_name_column
@@ -94,12 +94,12 @@ class _BeamContext:
         )
         self.basis = _corr_basis(list(np.asarray(corr_type).ravel()))
         self.full_jones = opts.beam_jones == "full"
-        if is_ddfacet_json:
-            from simms.skymodel.beams import load_ddfacet_beam_json, resolve_ddfacet_antenna_beams
+        if is_cattery_json:
+            from simms.skymodel.beams import load_cattery_beam_json, resolve_cattery_antenna_beams
 
-            ddfacet_cfg = load_ddfacet_beam_json(opts.primary_beam)
-            self.ant_type, self.providers, self.type_is_altaz = resolve_ddfacet_antenna_beams(
-                type_keys, mount, ddfacet_cfg, pol_basis=self.basis, l_axis=opts.beam_l_axis, m_axis=opts.beam_m_axis
+            cattery_cfg = load_cattery_beam_json(opts.primary_beam)
+            self.ant_type, self.providers, self.type_is_altaz = resolve_cattery_antenna_beams(
+                type_keys, mount, cattery_cfg, pol_basis=self.basis, l_axis=opts.beam_l_axis, m_axis=opts.beam_m_axis
             )
         else:
             beam_config = load_beam_config(opts.primary_beam)
@@ -522,8 +522,8 @@ def skysim(
     primary_beam: str | None = Field(
         None,
         description="Beam model config: a simms beam-config YAML mapping each ANTENNA telescope "
-        "name to a beam model, or a DDFacet heterogeneous-beam json (--Beam-FITSFile json form, "
-        "keyed by ANTENNA.NAME) if the path ends in .json. Requires a linear pol basis.",
+        "name to a beam model, or a Cattery/DDFacet heterogeneous-beam json (--Beam-FITSFile json "
+        "form, keyed by ANTENNA.NAME) if the path ends in .json. Requires a linear pol basis.",
         json_schema_extra={"abbreviation": "pb"},
     ),
     beam_band: Literal["UHF", "L"] = Field(
@@ -545,14 +545,14 @@ def skysim(
     ),
     beam_l_axis: Literal["-X", "X"] = Field(
         "-X",
-        description="Sign convention for a ddfacet-schema primary-beam FITS file's L axis (--primary-beam "
-        "'ddfacet' entries, or a .json config), matching DDFacet's --Beam-FITSLAxis.",
+        description="Sign convention for a cattery-schema primary-beam FITS file's L axis (--primary-beam "
+        "'cattery' entries, or a .json config), matching DDFacet's --Beam-FITSLAxis.",
         json_schema_extra={"abbreviation": "bla"},
     ),
     beam_m_axis: Literal["Y", "-Y"] = Field(
         "Y",
-        description="Sign convention for a ddfacet-schema primary-beam FITS file's M axis (--primary-beam "
-        "'ddfacet' entries, or a .json config), matching DDFacet's --Beam-FITSMAxis.",
+        description="Sign convention for a cattery-schema primary-beam FITS file's M axis (--primary-beam "
+        "'cattery' entries, or a .json config), matching DDFacet's --Beam-FITSMAxis.",
         json_schema_extra={"abbreviation": "bma"},
     ),
     field_id: int = Field(0, description="Field ID.", json_schema_extra={"abbreviation": "fi"}),

--- a/src/simms/apps/skysim.py
+++ b/src/simms/apps/skysim.py
@@ -523,7 +523,8 @@ def skysim(
         None,
         description="Beam model config: a simms beam-config YAML mapping each ANTENNA telescope "
         "name to a beam model, or a Cattery/DDFacet heterogeneous-beam json (--Beam-FITSFile json "
-        "form, keyed by ANTENNA.NAME) if the path ends in .json. Requires a linear pol basis.",
+        "form, keyed by ANTENNA.NAME) if the path ends in .json. For Cattery/DDFacet beams a "
+        "circular-correlation MS may be used when --beam-jones full is selected.",
         json_schema_extra={"abbreviation": "pb"},
     ),
     beam_band: Literal["UHF", "L"] = Field(

--- a/src/simms/apps/skysim.py
+++ b/src/simms/apps/skysim.py
@@ -546,14 +546,16 @@ def skysim(
     ),
     beam_l_axis: Literal["-X", "X"] = Field(
         "-X",
-        description="Sign convention for a cattery-schema primary-beam FITS file's L axis (--primary-beam "
-        "'cattery' entries, or a .json config), matching DDFacet's --Beam-FITSLAxis.",
+        description="Sign convention for a Cattery/DDFacet .json primary-beam config's L axis; "
+        "ignored for YAML beam configs, which specify their own axis convention. "
+        "Matches DDFacet's --Beam-FITSLAxis.",
         json_schema_extra={"abbreviation": "bla"},
     ),
     beam_m_axis: Literal["Y", "-Y"] = Field(
         "Y",
-        description="Sign convention for a cattery-schema primary-beam FITS file's M axis (--primary-beam "
-        "'cattery' entries, or a .json config), matching DDFacet's --Beam-FITSMAxis.",
+        description="Sign convention for a Cattery/DDFacet .json primary-beam config's M axis; "
+        "ignored for YAML beam configs, which specify their own axis convention. "
+        "Matches DDFacet's --Beam-FITSMAxis.",
         json_schema_extra={"abbreviation": "bma"},
     ),
     field_id: int = Field(0, description="Field ID.", json_schema_extra={"abbreviation": "fi"}),

--- a/src/simms/apps/skysim.py
+++ b/src/simms/apps/skysim.py
@@ -65,20 +65,26 @@ class _BeamContext:
     """Everything needed to attach a primary beam to a prepared sky."""
 
     def __init__(self, opts, ms, msds, ra0, dec0, ncorr):
-        beam_config = load_beam_config(opts.primary_beam)
         ant_ds = xds_from_table(f"{ms}::ANTENNA")[0]
         pol_ds = xds_from_table(f"{ms}::POLARIZATION")[0]
-        telescope_col = opts.telescope_name_column
-        if telescope_col not in ant_ds:
-            # The per-antenna telescope name is required and never inferred (a single,
-            # authoritative source). Fail clearly instead of guessing from e.g. dish size.
-            raise RuntimeError(
-                f"The ANTENNA table has no '{telescope_col}' column (the per-antenna telescope "
-                f"name that selects a primary beam). Create the MS with telsim, or point "
-                f"--telescope-name-column at the column that holds it."
-            )
-        tnames, mount, pos, t0, t1, interval, corr_type = dask.compute(
-            ant_ds[telescope_col].data,
+        # A DDFacet heterogeneous-beam json types antennas by raw ANTENNA.NAME (its own
+        # convention, exact/regex/cmd::default); simms' own beam-config YAML instead groups
+        # by the TELESCOPE_NAME-column label. Detect which by the config file's extension.
+        is_ddfacet_json = str(opts.primary_beam).lower().endswith(".json")
+        if is_ddfacet_json:
+            typing_col = "NAME"
+        else:
+            typing_col = opts.telescope_name_column
+            if typing_col not in ant_ds:
+                # The per-antenna telescope name is required and never inferred (a single,
+                # authoritative source). Fail clearly instead of guessing from e.g. dish size.
+                raise RuntimeError(
+                    f"The ANTENNA table has no '{typing_col}' column (the per-antenna telescope "
+                    f"name that selects a primary beam). Create the MS with telsim, or point "
+                    f"--telescope-name-column at the column that holds it."
+                )
+        type_keys, mount, pos, t0, t1, interval, corr_type = dask.compute(
+            ant_ds[typing_col].data,
             ant_ds.MOUNT.data,
             ant_ds.POSITION.data,
             msds.TIME.data.min(),
@@ -88,9 +94,18 @@ class _BeamContext:
         )
         self.basis = _corr_basis(list(np.asarray(corr_type).ravel()))
         self.full_jones = opts.beam_jones == "full"
-        self.ant_type, self.providers, self.type_is_altaz = resolve_antenna_beams(
-            tnames, mount, beam_config, opts.beam_band
-        )
+        if is_ddfacet_json:
+            from simms.skymodel.beams import load_ddfacet_beam_json, resolve_ddfacet_antenna_beams
+
+            ddfacet_cfg = load_ddfacet_beam_json(opts.primary_beam)
+            self.ant_type, self.providers, self.type_is_altaz = resolve_ddfacet_antenna_beams(
+                type_keys, mount, ddfacet_cfg, pol_basis=self.basis, l_axis=opts.beam_l_axis, m_axis=opts.beam_m_axis
+            )
+        else:
+            beam_config = load_beam_config(opts.primary_beam)
+            self.ant_type, self.providers, self.type_is_altaz = resolve_antenna_beams(
+                type_keys, mount, beam_config, opts.beam_band
+            )
         self.lon, self.lat = _array_lonlat(pos)
         # The beam is centred on the antenna pointing centre (POINTING.DIRECTION), not the phase
         # centre; source l/m are prepared for the phase centre, so keep it too for reprojection.
@@ -506,8 +521,9 @@ def skysim(
     ),
     primary_beam: str | None = Field(
         None,
-        description="Beam-config YAML mapping each ANTENNA telescope name to a beam model. "
-        "Requires a linear pol basis.",
+        description="Beam model config: a simms beam-config YAML mapping each ANTENNA telescope "
+        "name to a beam model, or a DDFacet heterogeneous-beam json (--Beam-FITSFile json form, "
+        "keyed by ANTENNA.NAME) if the path ends in .json. Requires a linear pol basis.",
         json_schema_extra={"abbreviation": "pb"},
     ),
     beam_band: Literal["UHF", "L"] = Field(
@@ -526,6 +542,18 @@ def skysim(
         "TELESCOPE_NAME",
         description="ANTENNA-table column holding the per-antenna telescope/type label that maps to a beam model.",
         json_schema_extra={"abbreviation": "tnc"},
+    ),
+    beam_l_axis: Literal["-X", "X"] = Field(
+        "-X",
+        description="Sign convention for a ddfacet-schema primary-beam FITS file's L axis (--primary-beam "
+        "'ddfacet' entries, or a .json config), matching DDFacet's --Beam-FITSLAxis.",
+        json_schema_extra={"abbreviation": "bla"},
+    ),
+    beam_m_axis: Literal["Y", "-Y"] = Field(
+        "Y",
+        description="Sign convention for a ddfacet-schema primary-beam FITS file's M axis (--primary-beam "
+        "'ddfacet' entries, or a .json config), matching DDFacet's --Beam-FITSMAxis.",
+        json_schema_extra={"abbreviation": "bma"},
     ),
     field_id: int = Field(0, description="Field ID.", json_schema_extra={"abbreviation": "fi"}),
     spw_id: int = Field(0, description="Spectral Window ID."),

--- a/src/simms/skymodel/beams.py
+++ b/src/simms/skymodel/beams.py
@@ -312,12 +312,13 @@ def _ascending(grid, values, axis):
     return grid, values
 
 
-def _ddfacet_substitute(pattern: str, *, stype: str = None, corr: str = None, reim: str = None) -> str:
-    """Apply DDFacet's ``$(...)`` beam-filename substitutions (and their uppercase forms).
+def _cattery_substitute(pattern: str, *, stype: str = None, corr: str = None, reim: str = None) -> str:
+    """Apply the Cattery/DDFacet ``$(...)`` beam-filename substitutions (and uppercase forms).
 
-    Mirrors the ``--Beam-FITSFile``/heterogeneous-beam-json substitution rules: ``$(stype)``,
-    ``$(corr)``/``$(xy)``, ``$(reim)``, ``$(realimag)``; an uppercase variable name (e.g.
-    ``$(REIM)``) is replaced by the uppercase value.
+    Mirrors DDFacet's ``--Beam-FITSFile``/heterogeneous-beam-json substitution rules (the
+    same convention MeqTrees' Cattery beam interpolator uses): ``$(stype)``, ``$(corr)``/
+    ``$(xy)``, ``$(reim)``, ``$(realimag)``; an uppercase variable name (e.g. ``$(REIM)``) is
+    replaced by the uppercase value.
     """
     subs = {}
     if stype is not None:
@@ -458,7 +459,7 @@ class FitsBeamProvider(BeamProvider):
         return cls(l_grid, m_grid, freqs_hz, values, name=name or str(path))
 
     @classmethod
-    def from_ddfacet(
+    def from_cattery(
         cls,
         pattern: str,
         pol_basis: str = "linear",
@@ -466,14 +467,14 @@ class FitsBeamProvider(BeamProvider):
         m_axis: str = "Y",
         name: str = "",
     ) -> "FitsBeamProvider":
-        """Load a DDFacet-schema (``--Beam-Model FITS``) 8-file beam set.
+        """Load a Cattery-schema (MeqTrees Cattery / DDFacet ``--Beam-Model FITS``) 8-file beam set.
 
-        ``pattern`` is either a bare prefix (as written by :func:`write_beam_fits_ddfacet`,
-        e.g. ``"beam"`` -> ``beam_xx_re.fits`` etc.) or a full DDFacet ``--Beam-FITSFile``
+        ``pattern`` is either a bare prefix (as written by :func:`write_beam_fits_cattery`,
+        e.g. ``"beam"`` -> ``beam_xx_re.fits`` etc.) or a full DDFacet-style ``--Beam-FITSFile``
         pattern containing ``$(corr)``/``$(xy)`` and ``$(reim)``/``$(realimag)`` placeholders
-        (see :func:`_ddfacet_substitute`; any ``$(stype)`` must already be resolved by the
+        (see :func:`_cattery_substitute`; any ``$(stype)`` must already be resolved by the
         caller). ``pol_basis``/``l_axis``/``m_axis`` must match what the files were written
-        with (see :func:`write_beam_fits_ddfacet`).
+        with (see :func:`write_beam_fits_cattery`).
 
         The returned provider always stores **feed-frame (linear H/V) voltages**, like every
         other provider in this module: a ``pol_basis="circular"`` file set is rotated back
@@ -503,13 +504,13 @@ class FitsBeamProvider(BeamProvider):
         for corr in labels:
             reim_data = {}
             for reim in ("re", "im"):
-                path = _ddfacet_substitute(pattern, corr=corr, reim=reim)
+                path = _cattery_substitute(pattern, corr=corr, reim=reim)
                 with fits.open(path) as hdul:
                     hdr = hdul[0].header
                     data = np.asarray(hdul[0].data, dtype=np.float64)
                 if data.ndim != 3:
                     raise ValueError(
-                        f"DDFacet beam file {path!r} must be a (nfreq, nm, nl) cube, got shape {data.shape}."
+                        f"Cattery beam file {path!r} must be a (nfreq, nm, nl) cube, got shape {data.shape}."
                     )
                 nf, nm, nl = data.shape
                 this_l = sign_l * np.radians(_axis(hdr, 1, nl))
@@ -520,7 +521,7 @@ class FitsBeamProvider(BeamProvider):
                 elif not (
                     np.allclose(l_grid, this_l) and np.allclose(m_grid, this_m) and np.allclose(freqs_hz, this_freqs)
                 ):
-                    raise ValueError(f"DDFacet beam file {path!r} has a different (l, m, freq) grid than the rest.")
+                    raise ValueError(f"Cattery beam file {path!r} has a different (l, m, freq) grid than the rest.")
                 reim_data[reim] = data
             planes.append(reim_data["re"] + 1j * reim_data["im"])  # (nf, nm, nl)
 
@@ -558,14 +559,14 @@ def _build_provider(label: str, beam_config, beam_band: str) -> BeamProvider:
         return _build_jimbeam(entry["jimbeam"], beam_band)
     if "fits" in entry:
         return FitsBeamProvider.from_fits(entry["fits"])
-    if "ddfacet" in entry:
-        return FitsBeamProvider.from_ddfacet(
-            entry["ddfacet"],
+    if "cattery" in entry:
+        return FitsBeamProvider.from_cattery(
+            entry["cattery"],
             pol_basis=entry.get("pol_basis", "linear"),
             l_axis=entry.get("l_axis", "-X"),
             m_axis=entry.get("m_axis", "Y"),
         )
-    log.warning("Beam entry for %r has no 'jimbeam', 'fits' or 'ddfacet' key; using a unity beam.", label)
+    log.warning("Beam entry for %r has no 'jimbeam', 'fits' or 'cattery' key; using a unity beam.", label)
     return UnityBeamProvider()
 
 
@@ -615,15 +616,17 @@ def resolve_antenna_beams(telescope_names, mount, beam_config, beam_band: str = 
     return ant_type, providers, np.array(type_is_altaz, dtype=bool)
 
 
-def load_ddfacet_beam_json(path) -> dict:
-    """Load DDFacet's heterogeneous-beam json config (the ``--Beam-FITSFile`` json form).
+def load_cattery_beam_json(path) -> dict:
+    """Load a Cattery/DDFacet heterogeneous-beam json config (the ``--Beam-FITSFile`` json form).
 
-    The schema is a dict of arbitrarily-named, chained top-level blocks, each holding a
-    ``"define-stationtypes"`` mapping (antenna ``NAME`` -> station-type label; a key
-    prefixed with ``~`` is a regex over antenna names instead of an exact match; the key
-    ``"cmd::default"`` is the fallback type for any antenna no other rule matches) and a
-    ``"patterns"`` mapping (arbitrary key -> list of ``$(stype)``-templated file patterns,
-    normally one list spanning different frequency ranges).
+    This json-based multi-antenna-type config is DDFacet's own convention layered on top of
+    the underlying Cattery-format beam FITS files it points at. The schema is a dict of
+    arbitrarily-named, chained top-level blocks, each holding a ``"define-stationtypes"``
+    mapping (antenna ``NAME`` -> station-type label; a key prefixed with ``~`` is a regex
+    over antenna names instead of an exact match; the key ``"cmd::default"`` is the fallback
+    type for any antenna no other rule matches) and a ``"patterns"`` mapping (arbitrary key
+    -> list of ``$(stype)``-templated file patterns, normally one list spanning different
+    frequency ranges).
 
     Returns ``{"stationtypes": [(matcher, is_regex, stype), ...], "pattern": pattern}``:
     ``stationtypes`` is flattened across every block in file order, with the *first* rule
@@ -655,25 +658,25 @@ def load_ddfacet_beam_json(path) -> dict:
 
     distinct = list(dict.fromkeys(patterns))
     if not distinct:
-        raise ValueError(f"DDFacet beam json {path!r} has no 'patterns' entries.")
+        raise ValueError(f"Cattery beam json {path!r} has no 'patterns' entries.")
     if len(distinct) > 1:
         raise ValueError(
-            f"DDFacet beam json {path!r} defines {len(distinct)} distinct file patterns "
+            f"Cattery beam json {path!r} defines {len(distinct)} distinct file patterns "
             "(multiple frequency-range patterns per station type); only a single pattern is supported."
         )
     return {"stationtypes": stationtypes, "pattern": distinct[0]}
 
 
-def resolve_ddfacet_antenna_beams(
-    antenna_names, mount, ddfacet_cfg: dict, pol_basis: str = "linear", l_axis: str = "-X", m_axis: str = "Y"
+def resolve_cattery_antenna_beams(
+    antenna_names, mount, cattery_cfg: dict, pol_basis: str = "linear", l_axis: str = "-X", m_axis: str = "Y"
 ):
-    """Map antennas to beam types from a DDFacet heterogeneous-beam json config.
+    """Map antennas to beam types from a Cattery/DDFacet heterogeneous-beam json config.
 
     Like :func:`resolve_antenna_beams`, but keys antenna typing by the raw ``ANTENNA.NAME``
     (DDFacet's own convention: exact match, ``~regex``, or the ``"cmd::default"`` fallback --
-    see :func:`load_ddfacet_beam_json`) rather than by the ``TELESCOPE_NAME`` column, and
-    loads each type's beam via :meth:`FitsBeamProvider.from_ddfacet` with ``$(stype)``
-    substituted into ``ddfacet_cfg["pattern"]``.
+    see :func:`load_cattery_beam_json`) rather than by the ``TELESCOPE_NAME`` column, and
+    loads each type's beam via :meth:`FitsBeamProvider.from_cattery` with ``$(stype)``
+    substituted into ``cattery_cfg["pattern"]``.
 
     Parameters
     ----------
@@ -681,10 +684,10 @@ def resolve_ddfacet_antenna_beams(
         Per-antenna ``ANTENNA.NAME`` values, length ``nant``.
     mount : sequence of str
         Per-antenna ``ANTENNA.MOUNT`` values, length ``nant``.
-    ddfacet_cfg : dict
-        As returned by :func:`load_ddfacet_beam_json`.
+    cattery_cfg : dict
+        As returned by :func:`load_cattery_beam_json`.
     pol_basis, l_axis, m_axis
-        Passed through to :meth:`FitsBeamProvider.from_ddfacet` (must match how the
+        Passed through to :meth:`FitsBeamProvider.from_cattery` (must match how the
         referenced FITS files were written).
 
     Returns
@@ -698,7 +701,7 @@ def resolve_ddfacet_antenna_beams(
     mount = [str(m) for m in np.asarray(mount).astype(str)]
 
     exact, regexes, default = {}, [], None
-    for matcher, is_regex, stype in ddfacet_cfg["stationtypes"]:
+    for matcher, is_regex, stype in cattery_cfg["stationtypes"]:
         if is_regex:
             regexes.append((matcher, stype))
         elif matcher == "cmd::default":
@@ -716,7 +719,7 @@ def resolve_ddfacet_antenna_beams(
         if default is not None:
             return default
         raise RuntimeError(
-            f"No DDFacet station type matches antenna {name!r} (no exact/regex rule and no "
+            f"No Cattery station type matches antenna {name!r} (no exact/regex rule and no "
             "'cmd::default' fallback in the beam json)."
         )
 
@@ -726,8 +729,8 @@ def resolve_ddfacet_antenna_beams(
     providers = []
     type_is_altaz = []
     for label in labels:
-        pattern = _ddfacet_substitute(ddfacet_cfg["pattern"], stype=label)
-        providers.append(FitsBeamProvider.from_ddfacet(pattern, pol_basis=pol_basis, l_axis=l_axis, m_axis=m_axis))
+        pattern = _cattery_substitute(cattery_cfg["pattern"], stype=label)
+        providers.append(FitsBeamProvider.from_cattery(pattern, pol_basis=pol_basis, l_axis=l_axis, m_axis=m_axis))
         first = types.index(label)
         type_is_altaz.append("ALT-AZ" in mount[first].upper())
 
@@ -1082,7 +1085,7 @@ def _axis_sign(spec: str) -> float:
     return -1.0 if str(spec).strip().startswith("-") else 1.0
 
 
-def write_beam_fits_ddfacet(
+def write_beam_fits_cattery(
     beam: CosineTaperBeam,
     l_grid,
     m_grid,
@@ -1092,15 +1095,16 @@ def write_beam_fits_ddfacet(
     l_axis: str = "-X",
     m_axis: str = "Y",
 ) -> list:
-    """Write a cosine-taper beam as DDFacet's 8-file FITS-beam schema.
+    """Write a cosine-taper beam as the Cattery 8-file FITS-beam schema.
 
-    DDFacet's ``[Beam]`` parset (``Beam-Model=FITS``) expects a real/imaginary pair
-    per entry of the 2x2 voltage Jones matrix -- **8 separate files** -- named by its
-    default ``Beam-FITSFile`` pattern ``beam_$(corr)_$(reim).fits``: here,
-    ``f"{prefix}_{corr}_{reim}.fits"`` with ``corr`` in ``xx,xy,yx,yy`` (linear feeds,
-    ``pol_basis="linear"``) or ``rr,rl,lr,ll`` (circular, ``pol_basis="circular"``) and
-    ``reim`` in ``re,im``. Each file is a ``(nfreq, nm, nl)`` cube: CTYPE1/2 are the
-    spatial axes (degrees), CTYPE3 is FREQ (Hz).
+    This is the beam-FITS layout used by MeqTrees' Cattery beam interpolator, and also
+    read by DDFacet (``[Beam]`` parset, ``Beam-Model=FITS``, which inherited the format
+    from Cattery): a real/imaginary pair per entry of the 2x2 voltage Jones matrix --
+    **8 separate files** -- named by DDFacet's default ``Beam-FITSFile`` pattern
+    ``beam_$(corr)_$(reim).fits``: here, ``f"{prefix}_{corr}_{reim}.fits"`` with ``corr``
+    in ``xx,xy,yx,yy`` (linear feeds, ``pol_basis="linear"``) or ``rr,rl,lr,ll`` (circular,
+    ``pol_basis="circular"``) and ``reim`` in ``re,im``. Each file is a ``(nfreq, nm, nl)``
+    cube: CTYPE1/2 are the spatial axes (degrees), CTYPE3 is FREQ (Hz).
 
     The cosine-taper model has no leakage, so the off-diagonal (xy/yx or rl/lr)
     planes are the diagonal Jones ``diag(HH, VV)`` with no cross terms, optionally
@@ -1124,7 +1128,7 @@ def write_beam_fits_ddfacet(
     freqs_hz = np.atleast_1d(np.asarray(freqs_hz, dtype=np.float64))
     nl, nm, nf = l_grid.size, m_grid.size, freqs_hz.size
     if nf > 2 and not np.allclose(np.diff(freqs_hz), freqs_hz[1] - freqs_hz[0]):
-        raise ValueError("write_beam_fits_ddfacet needs uniformly-spaced frequencies for the linear FITS FREQ axis.")
+        raise ValueError("write_beam_fits_cattery needs uniformly-spaced frequencies for the linear FITS FREQ axis.")
 
     ll, mm = np.meshgrid(l_grid, m_grid, indexing="ij")
     v = beam.voltages(np.degrees(ll.ravel()), np.degrees(mm.ravel()), freqs_hz / 1e6)  # (nl*nm, nf, 2)

--- a/src/simms/skymodel/beams.py
+++ b/src/simms/skymodel/beams.py
@@ -1099,9 +1099,15 @@ def write_beam_fits(beam: CosineTaperBeam, l_grid, m_grid, freqs_hz, path):
     fits.PrimaryHDU(data=data, header=hdr).writeto(path, overwrite=True)
 
 
+_VALID_AXIS_SIGNS = frozenset({"-X", "X", "-Y", "Y"})
+
+
 def _axis_sign(spec: str) -> float:
     """``"-X"``/``"-Y"`` -> ``-1.0``, ``"X"``/``"Y"`` -> ``1.0`` (DDFacet's FITSLAxis/FITSMAxis)."""
-    return -1.0 if str(spec).strip().startswith("-") else 1.0
+    spec = str(spec).strip()
+    if spec not in _VALID_AXIS_SIGNS:
+        raise ValueError(f"Invalid axis sign convention {spec!r}; expected one of {sorted(_VALID_AXIS_SIGNS)}.")
+    return -1.0 if spec.startswith("-") else 1.0
 
 
 def write_beam_fits_cattery(

--- a/src/simms/skymodel/beams.py
+++ b/src/simms/skymodel/beams.py
@@ -845,3 +845,88 @@ def write_beam_fits(beam: CosineTaperBeam, l_grid, m_grid, freqs_hz, path):
     hdr["CTYPE4"], hdr["CRPIX4"], hdr["CRVAL4"], hdr["CDELT4"] = "FEED", 1, 0, 1
     hdr["BUNIT"] = "1"
     fits.PrimaryHDU(data=data, header=hdr).writeto(path, overwrite=True)
+
+
+def _axis_sign(spec: str) -> float:
+    """``"-X"``/``"-Y"`` -> ``-1.0``, ``"X"``/``"Y"`` -> ``1.0`` (DDFacet's FITSLAxis/FITSMAxis)."""
+    return -1.0 if str(spec).strip().startswith("-") else 1.0
+
+
+def write_beam_fits_ddfacet(
+    beam: CosineTaperBeam,
+    l_grid,
+    m_grid,
+    freqs_hz,
+    prefix,
+    pol_basis: str = "linear",
+    l_axis: str = "-X",
+    m_axis: str = "Y",
+) -> list:
+    """Write a cosine-taper beam as DDFacet's 8-file FITS-beam schema.
+
+    DDFacet's ``[Beam]`` parset (``Beam-Model=FITS``) expects a real/imaginary pair
+    per entry of the 2x2 voltage Jones matrix -- **8 separate files** -- named by its
+    default ``Beam-FITSFile`` pattern ``beam_$(corr)_$(reim).fits``: here,
+    ``f"{prefix}_{corr}_{reim}.fits"`` with ``corr`` in ``xx,xy,yx,yy`` (linear feeds,
+    ``pol_basis="linear"``) or ``rr,rl,lr,ll`` (circular, ``pol_basis="circular"``) and
+    ``reim`` in ``re,im``. Each file is a ``(nfreq, nm, nl)`` cube: CTYPE1/2 are the
+    spatial axes (degrees), CTYPE3 is FREQ (Hz).
+
+    The cosine-taper model has no leakage, so the off-diagonal (xy/yx or rl/lr)
+    planes are the diagonal Jones ``diag(HH, VV)`` with no cross terms, optionally
+    rotated into the circular basis by :func:`corr_basis_transform` (a single
+    left-multiply ``E' = S @ E``, the same transform :func:`build_beam_grid_jones`
+    applies -- not the baseline-coherency ``S @ B @ S^H`` form).
+
+    ``l_axis``/``m_axis`` (``"-X"``/``"X"`` and ``"Y"``/``"-Y"``) mirror DDFacet's own
+    ``--Beam-FITSLAxis``/``--Beam-FITSMAxis`` options and their documented convention
+    ("Minus sign indicates reverse coordinate convention"): passing the same string to
+    this writer and to DDFacet round-trips to the identity, so the defaults here match
+    DDFacet's own defaults.
+    """
+    from astropy.io import fits
+
+    if pol_basis not in ("linear", "circular"):
+        raise ValueError(f"pol_basis must be 'linear' or 'circular', got {pol_basis!r}.")
+
+    l_grid = np.ascontiguousarray(l_grid, dtype=np.float64)
+    m_grid = np.ascontiguousarray(m_grid, dtype=np.float64)
+    freqs_hz = np.atleast_1d(np.asarray(freqs_hz, dtype=np.float64))
+    nl, nm, nf = l_grid.size, m_grid.size, freqs_hz.size
+    if nf > 2 and not np.allclose(np.diff(freqs_hz), freqs_hz[1] - freqs_hz[0]):
+        raise ValueError("write_beam_fits_ddfacet needs uniformly-spaced frequencies for the linear FITS FREQ axis.")
+
+    ll, mm = np.meshgrid(l_grid, m_grid, indexing="ij")
+    v = beam.voltages(np.degrees(ll.ravel()), np.degrees(mm.ravel()), freqs_hz / 1e6)  # (nl*nm, nf, 2)
+    v = v.reshape(nl, nm, nf, 2).transpose(2, 1, 0, 3)  # (nf, nm, nl, 2) = [H, V] voltages
+
+    jones = np.zeros(v.shape[:3] + (2, 2), dtype=np.complex128)  # (nf, nm, nl, 2, 2)
+    jones[..., 0, 0] = v[..., 0]
+    jones[..., 1, 1] = v[..., 1]
+    if pol_basis == "circular":
+        jones = np.einsum("ij,...jk->...ik", corr_basis_transform(True), jones)
+
+    labels = ["xx", "xy", "yx", "yy"] if pol_basis == "linear" else ["rr", "rl", "lr", "ll"]
+
+    sign_l = _axis_sign(l_axis)
+    sign_m = _axis_sign(m_axis)
+    dl = np.degrees(l_grid[1] - l_grid[0]) if nl > 1 else 1.0
+    dm = np.degrees(m_grid[1] - m_grid[0]) if nm > 1 else 1.0
+    df = float(freqs_hz[1] - freqs_hz[0]) if nf > 1 else 1e6
+
+    hdr = fits.Header()
+    hdr["CTYPE1"], hdr["CRPIX1"], hdr["CUNIT1"] = "X", 1, "deg"
+    hdr["CRVAL1"], hdr["CDELT1"] = sign_l * np.degrees(l_grid[0]), sign_l * dl
+    hdr["CTYPE2"], hdr["CRPIX2"], hdr["CUNIT2"] = "Y", 1, "deg"
+    hdr["CRVAL2"], hdr["CDELT2"] = sign_m * np.degrees(m_grid[0]), sign_m * dm
+    hdr["CTYPE3"], hdr["CRPIX3"], hdr["CRVAL3"], hdr["CDELT3"], hdr["CUNIT3"] = "FREQ", 1, float(freqs_hz[0]), df, "Hz"
+    hdr["BUNIT"] = "1"
+
+    paths = []
+    for (i, j), corr in zip([(0, 0), (0, 1), (1, 0), (1, 1)], labels):
+        plane = jones[..., i, j]
+        for part, suffix in ((plane.real, "re"), (plane.imag, "im")):
+            path = f"{prefix}_{corr}_{suffix}.fits"
+            fits.PrimaryHDU(data=part.astype(np.float32), header=hdr).writeto(path, overwrite=True)
+            paths.append(path)
+    return paths

--- a/src/simms/skymodel/beams.py
+++ b/src/simms/skymodel/beams.py
@@ -312,6 +312,31 @@ def _ascending(grid, values, axis):
     return grid, values
 
 
+def _ddfacet_substitute(pattern: str, *, stype: str = None, corr: str = None, reim: str = None) -> str:
+    """Apply DDFacet's ``$(...)`` beam-filename substitutions (and their uppercase forms).
+
+    Mirrors the ``--Beam-FITSFile``/heterogeneous-beam-json substitution rules: ``$(stype)``,
+    ``$(corr)``/``$(xy)``, ``$(reim)``, ``$(realimag)``; an uppercase variable name (e.g.
+    ``$(REIM)``) is replaced by the uppercase value.
+    """
+    subs = {}
+    if stype is not None:
+        subs["$(stype)"] = stype
+        subs["$(STYPE)"] = stype.upper()
+    if corr is not None:
+        subs["$(corr)"] = subs["$(xy)"] = corr
+        subs["$(CORR)"] = subs["$(XY)"] = corr.upper()
+    if reim is not None:
+        subs["$(reim)"] = reim
+        subs["$(REIM)"] = reim.upper()
+        realimag = {"re": "real", "im": "imag"}[reim]
+        subs["$(realimag)"] = realimag
+        subs["$(REALIMAG)"] = realimag.upper()
+    for key, val in subs.items():
+        pattern = pattern.replace(key, val)
+    return pattern
+
+
 class FitsBeamProvider(BeamProvider):
     """Per-feed voltage beam interpolated from a gridded FITS cube (measured/eidos beams).
 
@@ -432,6 +457,83 @@ class FitsBeamProvider(BeamProvider):
         values = np.ascontiguousarray(complex_planes.transpose(3, 2, 1, 0))  # (nl, nm, nfreq, nk)
         return cls(l_grid, m_grid, freqs_hz, values, name=name or str(path))
 
+    @classmethod
+    def from_ddfacet(
+        cls,
+        pattern: str,
+        pol_basis: str = "linear",
+        l_axis: str = "-X",
+        m_axis: str = "Y",
+        name: str = "",
+    ) -> "FitsBeamProvider":
+        """Load a DDFacet-schema (``--Beam-Model FITS``) 8-file beam set.
+
+        ``pattern`` is either a bare prefix (as written by :func:`write_beam_fits_ddfacet`,
+        e.g. ``"beam"`` -> ``beam_xx_re.fits`` etc.) or a full DDFacet ``--Beam-FITSFile``
+        pattern containing ``$(corr)``/``$(xy)`` and ``$(reim)``/``$(realimag)`` placeholders
+        (see :func:`_ddfacet_substitute`; any ``$(stype)`` must already be resolved by the
+        caller). ``pol_basis``/``l_axis``/``m_axis`` must match what the files were written
+        with (see :func:`write_beam_fits_ddfacet`).
+
+        The returned provider always stores **feed-frame (linear H/V) voltages**, like every
+        other provider in this module: a ``pol_basis="circular"`` file set is rotated back
+        with the inverse of :func:`corr_basis_transform` (a unitary matrix, so its inverse is
+        its conjugate transpose) immediately after loading, undoing the single left-multiply
+        the writer applied.
+        """
+        from astropy.io import fits
+
+        if pol_basis not in ("linear", "circular"):
+            raise ValueError(f"pol_basis must be 'linear' or 'circular', got {pol_basis!r}.")
+        has_placeholder = any(tok in pattern for tok in ("$(corr)", "$(xy)", "$(CORR)", "$(XY)"))
+        if not has_placeholder:
+            pattern = f"{pattern}_$(corr)_$(reim).fits"
+
+        labels = ["xx", "xy", "yx", "yy"] if pol_basis == "linear" else ["rr", "rl", "lr", "ll"]
+        sign_l, sign_m = _axis_sign(l_axis), _axis_sign(m_axis)
+
+        def _axis(hdr, fits_axis, n):
+            crpix = hdr[f"CRPIX{fits_axis}"]
+            crval = hdr[f"CRVAL{fits_axis}"]
+            cdelt = hdr[f"CDELT{fits_axis}"]
+            return (np.arange(n) - (crpix - 1)) * cdelt + crval
+
+        l_grid = m_grid = freqs_hz = None
+        planes = []
+        for corr in labels:
+            reim_data = {}
+            for reim in ("re", "im"):
+                path = _ddfacet_substitute(pattern, corr=corr, reim=reim)
+                with fits.open(path) as hdul:
+                    hdr = hdul[0].header
+                    data = np.asarray(hdul[0].data, dtype=np.float64)
+                if data.ndim != 3:
+                    raise ValueError(
+                        f"DDFacet beam file {path!r} must be a (nfreq, nm, nl) cube, got shape {data.shape}."
+                    )
+                nf, nm, nl = data.shape
+                this_l = sign_l * np.radians(_axis(hdr, 1, nl))
+                this_m = sign_m * np.radians(_axis(hdr, 2, nm))
+                this_freqs = _axis(hdr, 3, nf)
+                if l_grid is None:
+                    l_grid, m_grid, freqs_hz = this_l, this_m, this_freqs
+                elif not (
+                    np.allclose(l_grid, this_l) and np.allclose(m_grid, this_m) and np.allclose(freqs_hz, this_freqs)
+                ):
+                    raise ValueError(f"DDFacet beam file {path!r} has a different (l, m, freq) grid than the rest.")
+                reim_data[reim] = data
+            planes.append(reim_data["re"] + 1j * reim_data["im"])  # (nf, nm, nl)
+
+        complex_planes = np.stack(planes, axis=0)  # (4, nf, nm, nl) = [pp, pq, qp, qq]
+        values = np.ascontiguousarray(complex_planes.transpose(3, 2, 1, 0))  # (nl, nm, nf, 4)
+
+        if pol_basis == "circular":
+            s_inv = corr_basis_transform(True).conj().T
+            jones = np.einsum("ij,...jk->...ik", s_inv, values.reshape(values.shape[:3] + (2, 2)))
+            values = jones.reshape(values.shape[:3] + (4,))
+
+        return cls(l_grid, m_grid, freqs_hz, values, name=name or pattern)
+
 
 def _build_jimbeam(spec, beam_band: str) -> JimBeamProvider:
     """Build a JimBeam provider from a beam-config spec (band shorthand, built-in name, or CSV path)."""
@@ -456,7 +558,14 @@ def _build_provider(label: str, beam_config, beam_band: str) -> BeamProvider:
         return _build_jimbeam(entry["jimbeam"], beam_band)
     if "fits" in entry:
         return FitsBeamProvider.from_fits(entry["fits"])
-    log.warning("Beam entry for %r has no 'jimbeam' or 'fits' key; using a unity beam.", label)
+    if "ddfacet" in entry:
+        return FitsBeamProvider.from_ddfacet(
+            entry["ddfacet"],
+            pol_basis=entry.get("pol_basis", "linear"),
+            l_axis=entry.get("l_axis", "-X"),
+            m_axis=entry.get("m_axis", "Y"),
+        )
+    log.warning("Beam entry for %r has no 'jimbeam', 'fits' or 'ddfacet' key; using a unity beam.", label)
     return UnityBeamProvider()
 
 
@@ -503,6 +612,127 @@ def resolve_antenna_beams(telescope_names, mount, beam_config, beam_band: str = 
 
     index = {label: i for i, label in enumerate(labels)}
     ant_type = np.array([index[t] for t in telescope_names], dtype=np.int64)
+    return ant_type, providers, np.array(type_is_altaz, dtype=bool)
+
+
+def load_ddfacet_beam_json(path) -> dict:
+    """Load DDFacet's heterogeneous-beam json config (the ``--Beam-FITSFile`` json form).
+
+    The schema is a dict of arbitrarily-named, chained top-level blocks, each holding a
+    ``"define-stationtypes"`` mapping (antenna ``NAME`` -> station-type label; a key
+    prefixed with ``~`` is a regex over antenna names instead of an exact match; the key
+    ``"cmd::default"`` is the fallback type for any antenna no other rule matches) and a
+    ``"patterns"`` mapping (arbitrary key -> list of ``$(stype)``-templated file patterns,
+    normally one list spanning different frequency ranges).
+
+    Returns ``{"stationtypes": [(matcher, is_regex, stype), ...], "pattern": pattern}``:
+    ``stationtypes`` is flattened across every block in file order, with the *first* rule
+    for a given exact name/`"cmd::default"` winning (blocks only *add* rules -- "once a
+    station is type-specialized the type applies to ALL chained blocks"); resolution
+    priority within that list is exact name > regex > ``"cmd::default"``, not strict
+    block order (this loader does not replicate DDFacet's own block-by-block precedence
+    beyond that -- an edge case not documented precisely enough to reproduce without
+    reading DDFacet's source, which is out of scope here).
+
+    Scope: DDFacet allows a station type to list several patterns for different frequency
+    ranges (selected by proximity to the MS's SPW coverage); this loader supports only a
+    single resolved pattern and raises a clear error if the file defines more than one
+    distinct pattern, rather than silently guessing.
+    """
+    import json
+
+    with open(path) as fh:
+        cfg = json.load(fh)
+
+    stationtypes = []
+    patterns = []
+    for block in cfg.values():
+        for matcher, stype in block.get("define-stationtypes", {}).items():
+            is_regex = matcher.startswith("~")
+            stationtypes.append((matcher[1:] if is_regex else matcher, is_regex, stype))
+        for pattern_list in block.get("patterns", {}).values():
+            patterns.extend(pattern_list)
+
+    distinct = list(dict.fromkeys(patterns))
+    if not distinct:
+        raise ValueError(f"DDFacet beam json {path!r} has no 'patterns' entries.")
+    if len(distinct) > 1:
+        raise ValueError(
+            f"DDFacet beam json {path!r} defines {len(distinct)} distinct file patterns "
+            "(multiple frequency-range patterns per station type); only a single pattern is supported."
+        )
+    return {"stationtypes": stationtypes, "pattern": distinct[0]}
+
+
+def resolve_ddfacet_antenna_beams(
+    antenna_names, mount, ddfacet_cfg: dict, pol_basis: str = "linear", l_axis: str = "-X", m_axis: str = "Y"
+):
+    """Map antennas to beam types from a DDFacet heterogeneous-beam json config.
+
+    Like :func:`resolve_antenna_beams`, but keys antenna typing by the raw ``ANTENNA.NAME``
+    (DDFacet's own convention: exact match, ``~regex``, or the ``"cmd::default"`` fallback --
+    see :func:`load_ddfacet_beam_json`) rather than by the ``TELESCOPE_NAME`` column, and
+    loads each type's beam via :meth:`FitsBeamProvider.from_ddfacet` with ``$(stype)``
+    substituted into ``ddfacet_cfg["pattern"]``.
+
+    Parameters
+    ----------
+    antenna_names : sequence of str
+        Per-antenna ``ANTENNA.NAME`` values, length ``nant``.
+    mount : sequence of str
+        Per-antenna ``ANTENNA.MOUNT`` values, length ``nant``.
+    ddfacet_cfg : dict
+        As returned by :func:`load_ddfacet_beam_json`.
+    pol_basis, l_axis, m_axis
+        Passed through to :meth:`FitsBeamProvider.from_ddfacet` (must match how the
+        referenced FITS files were written).
+
+    Returns
+    -------
+    ant_type, providers, type_is_altaz
+        Same shapes/meaning as :func:`resolve_antenna_beams`.
+    """
+    import re
+
+    antenna_names = [str(a) for a in np.asarray(antenna_names).astype(str)]
+    mount = [str(m) for m in np.asarray(mount).astype(str)]
+
+    exact, regexes, default = {}, [], None
+    for matcher, is_regex, stype in ddfacet_cfg["stationtypes"]:
+        if is_regex:
+            regexes.append((matcher, stype))
+        elif matcher == "cmd::default":
+            if default is None:
+                default = stype
+        else:
+            exact.setdefault(matcher, stype)
+
+    def _stype(name):
+        if name in exact:
+            return exact[name]
+        for pat, stype in regexes:
+            if re.fullmatch(pat, name):
+                return stype
+        if default is not None:
+            return default
+        raise RuntimeError(
+            f"No DDFacet station type matches antenna {name!r} (no exact/regex rule and no "
+            "'cmd::default' fallback in the beam json)."
+        )
+
+    types = [_stype(name) for name in antenna_names]
+    labels = list(dict.fromkeys(types))  # unique, insertion-ordered
+
+    providers = []
+    type_is_altaz = []
+    for label in labels:
+        pattern = _ddfacet_substitute(ddfacet_cfg["pattern"], stype=label)
+        providers.append(FitsBeamProvider.from_ddfacet(pattern, pol_basis=pol_basis, l_axis=l_axis, m_axis=m_axis))
+        first = types.index(label)
+        type_is_altaz.append("ALT-AZ" in mount[first].upper())
+
+    index = {label: i for i, label in enumerate(labels)}
+    ant_type = np.array([index[t] for t in types], dtype=np.int64)
     return ant_type, providers, np.array(type_is_altaz, dtype=bool)
 
 

--- a/src/simms/skymodel/beams.py
+++ b/src/simms/skymodel/beams.py
@@ -486,7 +486,19 @@ class FitsBeamProvider(BeamProvider):
 
         if pol_basis not in ("linear", "circular"):
             raise ValueError(f"pol_basis must be 'linear' or 'circular', got {pol_basis!r}.")
-        has_placeholder = any(tok in pattern for tok in ("$(corr)", "$(xy)", "$(CORR)", "$(XY)"))
+        has_placeholder = any(
+            tok in pattern
+            for tok in (
+                "$(corr)",
+                "$(xy)",
+                "$(CORR)",
+                "$(XY)",
+                "$(reim)",
+                "$(REIM)",
+                "$(realimag)",
+                "$(REALIMAG)",
+            )
+        )
         if not has_placeholder:
             pattern = f"{pattern}_$(corr)_$(reim).fits"
 
@@ -505,6 +517,10 @@ class FitsBeamProvider(BeamProvider):
             reim_data = {}
             for reim in ("re", "im"):
                 path = _cattery_substitute(pattern, corr=corr, reim=reim)
+                if not Path(path).exists():
+                    raise FileNotFoundError(
+                        f"Cattery beam file {path!r} does not exist (resolved from pattern {pattern!r})."
+                    )
                 with fits.open(path) as hdul:
                     hdr = hdul[0].header
                     data = np.asarray(hdul[0].data, dtype=np.float64)
@@ -646,6 +662,9 @@ def load_cattery_beam_json(path) -> dict:
 
     with open(path) as fh:
         cfg = json.load(fh)
+
+    if not isinstance(cfg, dict):
+        raise ValueError(f"Cattery beam json {path!r} must contain a top-level JSON object, got {type(cfg).__name__}.")
 
     stationtypes = []
     patterns = []

--- a/src/simms/skymodel/pb_ops.py
+++ b/src/simms/skymodel/pb_ops.py
@@ -1,7 +1,8 @@
 """Operations for the ``simms primary-beam`` command.
 
 Four modes, none of which run a visibility simulation:
-- ``to_fits``      : sample an analytic cosine-taper beam onto a FITS beam cube.
+- ``to_fits``      : sample an analytic cosine-taper beam onto a FITS beam cube, in either
+  simms' own single-file layout or DDFacet's 8-file ``--Beam-Model FITS`` schema.
 - ``tag_ms``       : write the per-antenna telescope-name column onto an existing MS.
 - ``apply``/``correct`` : multiply / divide a sky model (FITS image or ASCII components) by
   the frequency- and parallactic-angle-averaged Stokes-I power beam ``A(l, m)``.
@@ -81,7 +82,7 @@ def _angular_separation(ra1, dec1, ra2, dec2):
 def to_fits(opts):
     from astropy.coordinates import Angle
 
-    from simms.skymodel.beams import JimBeamProvider, resolve_beam, write_beam_fits
+    from simms.skymodel.beams import JimBeamProvider, resolve_beam, write_beam_fits, write_beam_fits_ddfacet
 
     provider = resolve_beam(opts.beam_pattern, opts.beam_band)
     if not isinstance(provider, JimBeamProvider):
@@ -106,9 +107,29 @@ def to_fits(opts):
     else:
         freqs = np.array([start])
 
-    output = opts.output or "beam.fits"
-    write_beam_fits(beam, grid, grid, freqs, output)
-    log.info("Wrote beam FITS cube %s (%d x %d pixels, %d channels)", output, npix, npix, freqs.size)
+    if opts.fits_format == "ddfacet":
+        prefix = opts.output or "beam"
+        if prefix.lower().endswith(".fits"):
+            prefix = prefix[: -len(".fits")]
+        paths = write_beam_fits_ddfacet(
+            beam, grid, grid, freqs, prefix, pol_basis=opts.pol_basis, l_axis=opts.beam_l_axis, m_axis=opts.beam_m_axis
+        )
+        log.info(
+            "Wrote DDFacet-schema beam (%d x %d pixels, %d channels, %s basis) -> %s",
+            npix,
+            npix,
+            freqs.size,
+            opts.pol_basis,
+            ", ".join(paths),
+        )
+    else:
+        if opts.beam_l_axis != "-X" or opts.beam_m_axis != "Y":
+            log.warning(
+                "--beam-l-axis/--beam-m-axis only apply to --fits-format ddfacet; ignored for %r.", opts.fits_format
+            )
+        output = opts.output or "beam.fits"
+        write_beam_fits(beam, grid, grid, freqs, output)
+        log.info("Wrote beam FITS cube %s (%d x %d pixels, %d channels)", output, npix, npix, freqs.size)
 
 
 # --------------------------------------------------------------------- tag-ms

--- a/src/simms/skymodel/pb_ops.py
+++ b/src/simms/skymodel/pb_ops.py
@@ -2,7 +2,7 @@
 
 Four modes, none of which run a visibility simulation:
 - ``to_fits``      : sample an analytic cosine-taper beam onto a FITS beam cube, in either
-  simms' own single-file layout or DDFacet's 8-file ``--Beam-Model FITS`` schema.
+  simms' own single-file layout or the Cattery/DDFacet 8-file ``--Beam-Model FITS`` schema.
 - ``tag_ms``       : write the per-antenna telescope-name column onto an existing MS.
 - ``apply``/``correct`` : multiply / divide a sky model (FITS image or ASCII components) by
   the frequency- and parallactic-angle-averaged Stokes-I power beam ``A(l, m)``.
@@ -82,7 +82,7 @@ def _angular_separation(ra1, dec1, ra2, dec2):
 def to_fits(opts):
     from astropy.coordinates import Angle
 
-    from simms.skymodel.beams import JimBeamProvider, resolve_beam, write_beam_fits, write_beam_fits_ddfacet
+    from simms.skymodel.beams import JimBeamProvider, resolve_beam, write_beam_fits, write_beam_fits_cattery
 
     provider = resolve_beam(opts.beam_pattern, opts.beam_band)
     if not isinstance(provider, JimBeamProvider):
@@ -107,15 +107,15 @@ def to_fits(opts):
     else:
         freqs = np.array([start])
 
-    if opts.fits_format == "ddfacet":
+    if opts.fits_format == "cattery":
         prefix = opts.output or "beam"
         if prefix.lower().endswith(".fits"):
             prefix = prefix[: -len(".fits")]
-        paths = write_beam_fits_ddfacet(
+        paths = write_beam_fits_cattery(
             beam, grid, grid, freqs, prefix, pol_basis=opts.pol_basis, l_axis=opts.beam_l_axis, m_axis=opts.beam_m_axis
         )
         log.info(
-            "Wrote DDFacet-schema beam (%d x %d pixels, %d channels, %s basis) -> %s",
+            "Wrote Cattery-schema beam (%d x %d pixels, %d channels, %s basis) -> %s",
             npix,
             npix,
             freqs.size,
@@ -125,7 +125,7 @@ def to_fits(opts):
     else:
         if opts.beam_l_axis != "-X" or opts.beam_m_axis != "Y":
             log.warning(
-                "--beam-l-axis/--beam-m-axis only apply to --fits-format ddfacet; ignored for %r.", opts.fits_format
+                "--beam-l-axis/--beam-m-axis only apply to --fits-format cattery; ignored for %r.", opts.fits_format
             )
         output = opts.output or "beam.fits"
         write_beam_fits(beam, grid, grid, freqs, output)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -35,6 +35,8 @@ def skysim_opts(ms, ascii_sky=None, column="DATA", **overrides):
         "beam_pa_step": 1.0,
         "beam_grid_max_gib": 4.0,
         "beam_jones": "diagonal",
+        "beam_l_axis": "-X",
+        "beam_m_axis": "Y",
         "telescope_name_column": "TELESCOPE_NAME",
         "input_column": None,
         "mode": "sim",

--- a/tests/beam_tests.py
+++ b/tests/beam_tests.py
@@ -485,6 +485,135 @@ def test_resolve_antenna_beams_fits_entry(tmp_path):
     assert isinstance(providers[0], FitsBeamProvider)
 
 
+# --- DDFacet-schema FITS beams (read side) ----------------------------------------
+
+from simms.skymodel.beams import (  # noqa: E402
+    _ddfacet_substitute,
+    load_ddfacet_beam_json,
+    resolve_ddfacet_antenna_beams,
+    write_beam_fits_ddfacet,
+)
+
+
+def test_ddfacet_substitute():
+    assert _ddfacet_substitute("beam_$(corr)_$(reim).fits", corr="xx", reim="re") == "beam_xx_re.fits"
+    assert _ddfacet_substitute("beam_$(xy)_$(reim).fits", corr="rl", reim="im") == "beam_rl_im.fits"
+    assert _ddfacet_substitute("beam_$(CORR)_$(REIM).fits", corr="xx", reim="re") == "beam_XX_RE.fits"
+    assert _ddfacet_substitute("beam_$(realimag).fits", reim="im") == "beam_imag.fits"
+    assert _ddfacet_substitute("beam_$(REALIMAG).fits", reim="im") == "beam_IMAG.fits"
+    assert _ddfacet_substitute("$(stype)_$(corr)_$(reim).fits", stype="ska", corr="yy", reim="im") == "ska_yy_im.fits"
+    assert _ddfacet_substitute("$(STYPE)_beam.fits", stype="ska") == "SKA_beam.fits"
+
+
+@pytest.mark.parametrize("pol_basis", ["linear", "circular"])
+def test_fits_provider_from_ddfacet_roundtrip(tmp_path, pol_basis):
+    # write_beam_fits_ddfacet -> FitsBeamProvider.from_ddfacet must recover the same
+    # feed-frame voltages as the analytic beam, for both the linear and (un-rotated)
+    # circular on-disk basis.
+    beam = CosineTaperBeam.from_builtin("MKAT-EA-L-JIM-2026")
+    npix = 33
+    grid = (np.arange(npix) - npix // 2) * np.radians(2.0 / 60.0)
+    freqs = np.array([1.3e9, 1.4e9])
+    prefix = str(tmp_path / "beam")
+
+    write_beam_fits_ddfacet(beam, grid, grid, freqs, prefix, pol_basis=pol_basis)
+    prov = FitsBeamProvider.from_ddfacet(prefix, pol_basis=pol_basis)
+    assert prov.has_leakage
+
+    jim = JimBeamProvider(beam)
+    ell = np.array([0.001, -0.002])
+    emm = np.array([0.0005, 0.0008])
+    got = prov.voltage(ell, emm, freqs, np.array([0.0]))
+    want = jim.voltage(ell, emm, freqs, np.array([0.0]))
+    np.testing.assert_allclose(got, want, atol=2e-3)
+
+    # No leakage in the cosine-taper model.
+    jones = prov.jones(ell, emm, freqs, np.array([0.0]))
+    np.testing.assert_allclose(jones[..., 0, 1], 0.0, atol=1e-9)
+    np.testing.assert_allclose(jones[..., 1, 0], 0.0, atol=1e-9)
+
+
+def test_resolve_antenna_beams_ddfacet_entry(tmp_path):
+    # A {ddfacet: prefix} entry builds a FitsBeamProvider from the 8-file schema.
+    beam = CosineTaperBeam.from_builtin("MKAT-EA-L-JIM-2026")
+    npix = 17
+    grid = (np.arange(npix) - npix // 2) * np.radians(2.0 / 60.0)
+    freqs = np.array([1.4e9])
+    prefix = str(tmp_path / "beam")
+    write_beam_fits_ddfacet(beam, grid, grid, freqs, prefix, pol_basis="linear")
+
+    _, providers, _ = resolve_antenna_beams(["MKAT-EA"], ["ALT-AZ"], {"MKAT-EA": {"ddfacet": prefix}})
+    assert isinstance(providers[0], FitsBeamProvider)
+
+
+def test_load_ddfacet_beam_json_and_resolve(tmp_path):
+    import json
+
+    beam_meerkat = CosineTaperBeam.from_builtin("MKAT-EA-L-JIM-2026")
+    beam_ska = CosineTaperBeam.from_builtin("MKAT-AA-L-JIM-2020")
+    npix = 17
+    grid = (np.arange(npix) - npix // 2) * np.radians(2.0 / 60.0)
+    freqs = np.array([1.4e9])
+    write_beam_fits_ddfacet(beam_meerkat, grid, grid, freqs, str(tmp_path / "meerkat"), pol_basis="linear")
+    write_beam_fits_ddfacet(beam_ska, grid, grid, freqs, str(tmp_path / "ska"), pol_basis="linear")
+
+    cfg = {
+        "lband": {
+            "patterns": {"cmd::default": [str(tmp_path / "$(stype)_$(corr)_$(reim).fits")]},
+            "define-stationtypes": {"cmd::default": "meerkat", "~SKA[0-9]{3}": "ska"},
+        }
+    }
+    cfg_path = tmp_path / "beams.json"
+    cfg_path.write_text(json.dumps(cfg))
+
+    ddfacet_cfg = load_ddfacet_beam_json(cfg_path)
+    names = ["M060", "M061", "SKA001", "SKA002"]
+    mount = ["ALT-AZ"] * 4
+    ant_type, providers, is_altaz = resolve_ddfacet_antenna_beams(names, mount, ddfacet_cfg)
+
+    # M060/M061 share a provider (meerkat), SKA001/SKA002 share a different one (ska).
+    assert ant_type[0] == ant_type[1]
+    assert ant_type[2] == ant_type[3]
+    assert ant_type[0] != ant_type[2]
+    assert np.all(is_altaz)
+
+    ell, emm = np.array([0.001]), np.array([0.0005])
+    got_meerkat = providers[ant_type[0]].voltage(ell, emm, freqs, np.array([0.0]))
+    got_ska = providers[ant_type[2]].voltage(ell, emm, freqs, np.array([0.0]))
+    want_meerkat = JimBeamProvider(beam_meerkat).voltage(ell, emm, freqs, np.array([0.0]))
+    want_ska = JimBeamProvider(beam_ska).voltage(ell, emm, freqs, np.array([0.0]))
+    np.testing.assert_allclose(got_meerkat, want_meerkat, atol=2e-3)
+    np.testing.assert_allclose(got_ska, want_ska, atol=2e-3)
+
+
+def test_load_ddfacet_beam_json_rejects_multiple_patterns(tmp_path):
+    import json
+
+    cfg = {
+        "lband": {
+            "patterns": {"a": ["$(stype)_$(corr)_$(reim).fits"], "b": ["other_$(corr)_$(reim).fits"]},
+            "define-stationtypes": {"cmd::default": "meerkat"},
+        }
+    }
+    cfg_path = tmp_path / "beams.json"
+    cfg_path.write_text(json.dumps(cfg))
+    with pytest.raises(ValueError, match="distinct file patterns"):
+        load_ddfacet_beam_json(cfg_path)
+
+
+def test_resolve_ddfacet_antenna_beams_no_match_raises(tmp_path):
+    beam = CosineTaperBeam.from_builtin("MKAT-EA-L-JIM-2026")
+    npix = 9
+    grid = (np.arange(npix) - npix // 2) * np.radians(2.0 / 60.0)
+    write_beam_fits_ddfacet(beam, grid, grid, np.array([1.4e9]), str(tmp_path / "meerkat"), pol_basis="linear")
+    ddfacet_cfg = {
+        "stationtypes": [("~M0[0-9]{2}", True, "meerkat")],
+        "pattern": str(tmp_path / "$(stype)_$(corr)_$(reim).fits"),
+    }
+    with pytest.raises(RuntimeError, match="No DDFacet station type"):
+        resolve_ddfacet_antenna_beams(["SKA001"], ["ALT-AZ"], ddfacet_cfg)
+
+
 # --- FITS-image approximate power beam (Phase 5) ---------------------------------
 
 from simms.skymodel.beams import image_power_beam, pa_sample_grid  # noqa: E402

--- a/tests/beam_tests.py
+++ b/tests/beam_tests.py
@@ -488,6 +488,7 @@ def test_resolve_antenna_beams_fits_entry(tmp_path):
 # --- Cattery-schema FITS beams (read side) ----------------------------------------
 
 from simms.skymodel.beams import (  # noqa: E402
+    _axis_sign,
     _cattery_substitute,
     load_cattery_beam_json,
     resolve_cattery_antenna_beams,
@@ -503,6 +504,17 @@ def test_cattery_substitute():
     assert _cattery_substitute("beam_$(REALIMAG).fits", reim="im") == "beam_IMAG.fits"
     assert _cattery_substitute("$(stype)_$(corr)_$(reim).fits", stype="ska", corr="yy", reim="im") == "ska_yy_im.fits"
     assert _cattery_substitute("$(STYPE)_beam.fits", stype="ska") == "SKA_beam.fits"
+
+
+@pytest.mark.parametrize("spec, expected", [("-X", -1.0), ("X", 1.0), ("-Y", -1.0), ("Y", 1.0)])
+def test_axis_sign_valid(spec, expected):
+    assert _axis_sign(spec) == expected
+
+
+@pytest.mark.parametrize("spec", ["-x", "x", "foo", "-Z", ""])
+def test_axis_sign_invalid(spec):
+    with pytest.raises(ValueError, match="Invalid axis sign convention"):
+        _axis_sign(spec)
 
 
 @pytest.mark.parametrize("pol_basis", ["linear", "circular"])

--- a/tests/beam_tests.py
+++ b/tests/beam_tests.py
@@ -485,29 +485,29 @@ def test_resolve_antenna_beams_fits_entry(tmp_path):
     assert isinstance(providers[0], FitsBeamProvider)
 
 
-# --- DDFacet-schema FITS beams (read side) ----------------------------------------
+# --- Cattery-schema FITS beams (read side) ----------------------------------------
 
 from simms.skymodel.beams import (  # noqa: E402
-    _ddfacet_substitute,
-    load_ddfacet_beam_json,
-    resolve_ddfacet_antenna_beams,
-    write_beam_fits_ddfacet,
+    _cattery_substitute,
+    load_cattery_beam_json,
+    resolve_cattery_antenna_beams,
+    write_beam_fits_cattery,
 )
 
 
-def test_ddfacet_substitute():
-    assert _ddfacet_substitute("beam_$(corr)_$(reim).fits", corr="xx", reim="re") == "beam_xx_re.fits"
-    assert _ddfacet_substitute("beam_$(xy)_$(reim).fits", corr="rl", reim="im") == "beam_rl_im.fits"
-    assert _ddfacet_substitute("beam_$(CORR)_$(REIM).fits", corr="xx", reim="re") == "beam_XX_RE.fits"
-    assert _ddfacet_substitute("beam_$(realimag).fits", reim="im") == "beam_imag.fits"
-    assert _ddfacet_substitute("beam_$(REALIMAG).fits", reim="im") == "beam_IMAG.fits"
-    assert _ddfacet_substitute("$(stype)_$(corr)_$(reim).fits", stype="ska", corr="yy", reim="im") == "ska_yy_im.fits"
-    assert _ddfacet_substitute("$(STYPE)_beam.fits", stype="ska") == "SKA_beam.fits"
+def test_cattery_substitute():
+    assert _cattery_substitute("beam_$(corr)_$(reim).fits", corr="xx", reim="re") == "beam_xx_re.fits"
+    assert _cattery_substitute("beam_$(xy)_$(reim).fits", corr="rl", reim="im") == "beam_rl_im.fits"
+    assert _cattery_substitute("beam_$(CORR)_$(REIM).fits", corr="xx", reim="re") == "beam_XX_RE.fits"
+    assert _cattery_substitute("beam_$(realimag).fits", reim="im") == "beam_imag.fits"
+    assert _cattery_substitute("beam_$(REALIMAG).fits", reim="im") == "beam_IMAG.fits"
+    assert _cattery_substitute("$(stype)_$(corr)_$(reim).fits", stype="ska", corr="yy", reim="im") == "ska_yy_im.fits"
+    assert _cattery_substitute("$(STYPE)_beam.fits", stype="ska") == "SKA_beam.fits"
 
 
 @pytest.mark.parametrize("pol_basis", ["linear", "circular"])
-def test_fits_provider_from_ddfacet_roundtrip(tmp_path, pol_basis):
-    # write_beam_fits_ddfacet -> FitsBeamProvider.from_ddfacet must recover the same
+def test_fits_provider_from_cattery_roundtrip(tmp_path, pol_basis):
+    # write_beam_fits_cattery -> FitsBeamProvider.from_cattery must recover the same
     # feed-frame voltages as the analytic beam, for both the linear and (un-rotated)
     # circular on-disk basis.
     beam = CosineTaperBeam.from_builtin("MKAT-EA-L-JIM-2026")
@@ -516,8 +516,8 @@ def test_fits_provider_from_ddfacet_roundtrip(tmp_path, pol_basis):
     freqs = np.array([1.3e9, 1.4e9])
     prefix = str(tmp_path / "beam")
 
-    write_beam_fits_ddfacet(beam, grid, grid, freqs, prefix, pol_basis=pol_basis)
-    prov = FitsBeamProvider.from_ddfacet(prefix, pol_basis=pol_basis)
+    write_beam_fits_cattery(beam, grid, grid, freqs, prefix, pol_basis=pol_basis)
+    prov = FitsBeamProvider.from_cattery(prefix, pol_basis=pol_basis)
     assert prov.has_leakage
 
     jim = JimBeamProvider(beam)
@@ -533,20 +533,20 @@ def test_fits_provider_from_ddfacet_roundtrip(tmp_path, pol_basis):
     np.testing.assert_allclose(jones[..., 1, 0], 0.0, atol=1e-9)
 
 
-def test_resolve_antenna_beams_ddfacet_entry(tmp_path):
-    # A {ddfacet: prefix} entry builds a FitsBeamProvider from the 8-file schema.
+def test_resolve_antenna_beams_cattery_entry(tmp_path):
+    # A {cattery: prefix} entry builds a FitsBeamProvider from the 8-file schema.
     beam = CosineTaperBeam.from_builtin("MKAT-EA-L-JIM-2026")
     npix = 17
     grid = (np.arange(npix) - npix // 2) * np.radians(2.0 / 60.0)
     freqs = np.array([1.4e9])
     prefix = str(tmp_path / "beam")
-    write_beam_fits_ddfacet(beam, grid, grid, freqs, prefix, pol_basis="linear")
+    write_beam_fits_cattery(beam, grid, grid, freqs, prefix, pol_basis="linear")
 
-    _, providers, _ = resolve_antenna_beams(["MKAT-EA"], ["ALT-AZ"], {"MKAT-EA": {"ddfacet": prefix}})
+    _, providers, _ = resolve_antenna_beams(["MKAT-EA"], ["ALT-AZ"], {"MKAT-EA": {"cattery": prefix}})
     assert isinstance(providers[0], FitsBeamProvider)
 
 
-def test_load_ddfacet_beam_json_and_resolve(tmp_path):
+def test_load_cattery_beam_json_and_resolve(tmp_path):
     import json
 
     beam_meerkat = CosineTaperBeam.from_builtin("MKAT-EA-L-JIM-2026")
@@ -554,8 +554,8 @@ def test_load_ddfacet_beam_json_and_resolve(tmp_path):
     npix = 17
     grid = (np.arange(npix) - npix // 2) * np.radians(2.0 / 60.0)
     freqs = np.array([1.4e9])
-    write_beam_fits_ddfacet(beam_meerkat, grid, grid, freqs, str(tmp_path / "meerkat"), pol_basis="linear")
-    write_beam_fits_ddfacet(beam_ska, grid, grid, freqs, str(tmp_path / "ska"), pol_basis="linear")
+    write_beam_fits_cattery(beam_meerkat, grid, grid, freqs, str(tmp_path / "meerkat"), pol_basis="linear")
+    write_beam_fits_cattery(beam_ska, grid, grid, freqs, str(tmp_path / "ska"), pol_basis="linear")
 
     cfg = {
         "lband": {
@@ -566,10 +566,10 @@ def test_load_ddfacet_beam_json_and_resolve(tmp_path):
     cfg_path = tmp_path / "beams.json"
     cfg_path.write_text(json.dumps(cfg))
 
-    ddfacet_cfg = load_ddfacet_beam_json(cfg_path)
+    cattery_cfg = load_cattery_beam_json(cfg_path)
     names = ["M060", "M061", "SKA001", "SKA002"]
     mount = ["ALT-AZ"] * 4
-    ant_type, providers, is_altaz = resolve_ddfacet_antenna_beams(names, mount, ddfacet_cfg)
+    ant_type, providers, is_altaz = resolve_cattery_antenna_beams(names, mount, cattery_cfg)
 
     # M060/M061 share a provider (meerkat), SKA001/SKA002 share a different one (ska).
     assert ant_type[0] == ant_type[1]
@@ -586,7 +586,7 @@ def test_load_ddfacet_beam_json_and_resolve(tmp_path):
     np.testing.assert_allclose(got_ska, want_ska, atol=2e-3)
 
 
-def test_load_ddfacet_beam_json_rejects_multiple_patterns(tmp_path):
+def test_load_cattery_beam_json_rejects_multiple_patterns(tmp_path):
     import json
 
     cfg = {
@@ -598,20 +598,20 @@ def test_load_ddfacet_beam_json_rejects_multiple_patterns(tmp_path):
     cfg_path = tmp_path / "beams.json"
     cfg_path.write_text(json.dumps(cfg))
     with pytest.raises(ValueError, match="distinct file patterns"):
-        load_ddfacet_beam_json(cfg_path)
+        load_cattery_beam_json(cfg_path)
 
 
-def test_resolve_ddfacet_antenna_beams_no_match_raises(tmp_path):
+def test_resolve_cattery_antenna_beams_no_match_raises(tmp_path):
     beam = CosineTaperBeam.from_builtin("MKAT-EA-L-JIM-2026")
     npix = 9
     grid = (np.arange(npix) - npix // 2) * np.radians(2.0 / 60.0)
-    write_beam_fits_ddfacet(beam, grid, grid, np.array([1.4e9]), str(tmp_path / "meerkat"), pol_basis="linear")
-    ddfacet_cfg = {
+    write_beam_fits_cattery(beam, grid, grid, np.array([1.4e9]), str(tmp_path / "meerkat"), pol_basis="linear")
+    cattery_cfg = {
         "stationtypes": [("~M0[0-9]{2}", True, "meerkat")],
         "pattern": str(tmp_path / "$(stype)_$(corr)_$(reim).fits"),
     }
-    with pytest.raises(RuntimeError, match="No DDFacet station type"):
-        resolve_ddfacet_antenna_beams(["SKA001"], ["ALT-AZ"], ddfacet_cfg)
+    with pytest.raises(RuntimeError, match="No Cattery station type"):
+        resolve_cattery_antenna_beams(["SKA001"], ["ALT-AZ"], cattery_cfg)
 
 
 # --- FITS-image approximate power beam (Phase 5) ---------------------------------

--- a/tests/beam_tests.py
+++ b/tests/beam_tests.py
@@ -614,6 +614,29 @@ def test_resolve_cattery_antenna_beams_no_match_raises(tmp_path):
         resolve_cattery_antenna_beams(["SKA001"], ["ALT-AZ"], cattery_cfg)
 
 
+def test_fits_provider_from_cattery_reim_placeholder_no_double_suffix(tmp_path):
+    # A pattern that contains $(reim) but no $(corr) placeholder must not have the
+    # default _$(corr)_$(reim).fits suffix appended (the $(reim) token is enough).
+    pattern = str(tmp_path / "beam_$(reim).fits")
+    with pytest.raises(FileNotFoundError, match=r"beam_re\.fits"):
+        FitsBeamProvider.from_cattery(pattern, pol_basis="linear")
+
+
+def test_fits_provider_from_cattery_missing_file(tmp_path):
+    pattern = str(tmp_path / "nowhere_$(corr)_$(reim).fits")
+    with pytest.raises(FileNotFoundError, match="resolved from pattern"):
+        FitsBeamProvider.from_cattery(pattern, pol_basis="linear")
+
+
+def test_load_cattery_beam_json_rejects_non_object(tmp_path):
+    import json
+
+    cfg_path = tmp_path / "bad.json"
+    cfg_path.write_text(json.dumps(["not", "a", "dict"]))
+    with pytest.raises(ValueError, match="top-level JSON object"):
+        load_cattery_beam_json(cfg_path)
+
+
 # --- FITS-image approximate power beam (Phase 5) ---------------------------------
 
 from simms.skymodel.beams import image_power_beam, pa_sample_grid  # noqa: E402

--- a/tests/predict_beam_e2e_tests.py
+++ b/tests/predict_beam_e2e_tests.py
@@ -232,22 +232,22 @@ def test_fits_image_beam_accepts_circular_ms(e2e):
     assert np.abs(beam).mean() <= np.abs(nobeam).mean()
 
 
-def test_primary_beam_accepts_ddfacet_json(e2e):
-    # A DDFacet heterogeneous-beam json (typed by raw ANTENNA.NAME via a regex rule, not
+def test_primary_beam_accepts_cattery_json(e2e):
+    # A Cattery/DDFacet heterogeneous-beam json (typed by raw ANTENNA.NAME via a regex rule, not
     # TELESCOPE_NAME) must attenuate the same way as the equivalent simms beam-config YAML.
     import json
 
-    from simms.skymodel.beams import CosineTaperBeam, write_beam_fits_ddfacet
+    from simms.skymodel.beams import CosineTaperBeam, write_beam_fits_cattery
 
     npix = 33
     grid = (np.arange(npix) - npix // 2) * np.radians(2.0 / 60.0)
     freqs = np.array([1.412e9, 1.424e9])  # spans the MS's 1420MHz +/- 4MHz channels
     meerkat_prefix = e2e.random_named_file(suffix="")
     ska_prefix = e2e.random_named_file(suffix="")
-    write_beam_fits_ddfacet(
+    write_beam_fits_cattery(
         CosineTaperBeam.from_builtin("MKAT-MA-L-JIM-2026"), grid, grid, freqs, meerkat_prefix, pol_basis="linear"
     )
-    write_beam_fits_ddfacet(
+    write_beam_fits_cattery(
         CosineTaperBeam.from_builtin("MKAT-EA-L-JIM-2026"), grid, grid, freqs, ska_prefix, pol_basis="linear"
     )
     for prefix in (meerkat_prefix, ska_prefix):
@@ -268,11 +268,11 @@ def test_primary_beam_accepts_ddfacet_json(e2e):
     with open(cfg_json, "w") as fh:
         json.dump(cfg, fh)
 
-    skysim.runit(_opts(e2e.ms, e2e.sky, primary_beam=cfg_json, column="DDFJSON"))
+    skysim.runit(_opts(e2e.ms, e2e.sky, primary_beam=cfg_json, column="CATTERYJSON"))
     skysim.runit(_opts(e2e.ms, e2e.sky, primary_beam=None, column="NOBEAM"))
 
     ds = xds_from_ms(e2e.ms)[0]
-    beam = ds.DDFJSON.data.compute()
+    beam = ds.CATTERYJSON.data.compute()
     nobeam = ds.NOBEAM.data.compute()
     assert np.all(np.isfinite(beam))
     assert not np.allclose(beam, nobeam)

--- a/tests/predict_beam_e2e_tests.py
+++ b/tests/predict_beam_e2e_tests.py
@@ -232,6 +232,53 @@ def test_fits_image_beam_accepts_circular_ms(e2e):
     assert np.abs(beam).mean() <= np.abs(nobeam).mean()
 
 
+def test_primary_beam_accepts_ddfacet_json(e2e):
+    # A DDFacet heterogeneous-beam json (typed by raw ANTENNA.NAME via a regex rule, not
+    # TELESCOPE_NAME) must attenuate the same way as the equivalent simms beam-config YAML.
+    import json
+
+    from simms.skymodel.beams import CosineTaperBeam, write_beam_fits_ddfacet
+
+    npix = 33
+    grid = (np.arange(npix) - npix // 2) * np.radians(2.0 / 60.0)
+    freqs = np.array([1.412e9, 1.424e9])  # spans the MS's 1420MHz +/- 4MHz channels
+    meerkat_prefix = e2e.random_named_file(suffix="")
+    ska_prefix = e2e.random_named_file(suffix="")
+    write_beam_fits_ddfacet(
+        CosineTaperBeam.from_builtin("MKAT-MA-L-JIM-2026"), grid, grid, freqs, meerkat_prefix, pol_basis="linear"
+    )
+    write_beam_fits_ddfacet(
+        CosineTaperBeam.from_builtin("MKAT-EA-L-JIM-2026"), grid, grid, freqs, ska_prefix, pol_basis="linear"
+    )
+    for prefix in (meerkat_prefix, ska_prefix):
+        for corr in ("xx", "xy", "yx", "yy"):
+            for reim in ("re", "im"):
+                e2e.test_files.append(f"{prefix}_{corr}_{reim}.fits")
+
+    # define-stationtypes maps antenna NAME (here the skamid fixture's M060.. / SKA00.. split,
+    # via a regex) to a $(stype) value; patterns substitutes it straight into the file prefix,
+    # so the type value can just be the absolute beam-set prefix itself.
+    cfg = {
+        "lband": {
+            "patterns": {"cmd::default": ["$(stype)_$(corr)_$(reim).fits"]},
+            "define-stationtypes": {"cmd::default": meerkat_prefix, "~SKA[0-9]{3}": ska_prefix},
+        }
+    }
+    cfg_json = e2e.random_named_file(suffix=".json")
+    with open(cfg_json, "w") as fh:
+        json.dump(cfg, fh)
+
+    skysim.runit(_opts(e2e.ms, e2e.sky, primary_beam=cfg_json, column="DDFJSON"))
+    skysim.runit(_opts(e2e.ms, e2e.sky, primary_beam=None, column="NOBEAM"))
+
+    ds = xds_from_ms(e2e.ms)[0]
+    beam = ds.DDFJSON.data.compute()
+    nobeam = ds.NOBEAM.data.compute()
+    assert np.all(np.isfinite(beam))
+    assert not np.allclose(beam, nobeam)
+    assert np.abs(beam).mean() < np.abs(nobeam).mean()
+
+
 def test_configurable_telescope_name_column(e2e):
     # telsim writes the label to a custom column; skysim must read the same name, and
     # the default name (absent here) must fail clearly rather than infer the metadata.

--- a/tests/primary_beam_tests.py
+++ b/tests/primary_beam_tests.py
@@ -1,6 +1,7 @@
 """Tests for the `simms primary-beam` utility (to-fits, tag-ms, apply, correct)."""
 
 import logging
+import os
 
 import numpy as np
 import pytest
@@ -23,6 +24,10 @@ def _opts(mode, **over):
         "beam_pattern": "MKAT-EA-L-JIM-2026",
         "beam_band": "L",
         "beam_pa_step": 1.0,
+        "fits_format": "simms",
+        "pol_basis": "linear",
+        "beam_l_axis": "-X",
+        "beam_m_axis": "Y",
         "ms": None,
         "fits_sky": None,
         "ascii_sky": None,
@@ -105,6 +110,133 @@ def test_to_fits_roundtrips_through_provider(fx):
         jim.voltage(ell, emm, freqs, np.array([0.0])),
         atol=3e-3,
     )
+
+
+def _ddfacet_paths(prefix, labels):
+    return {(corr, ri): f"{prefix}_{corr}_{ri}.fits" for corr in labels for ri in ("re", "im")}
+
+
+def test_to_fits_ddfacet_writes_eight_files_and_matches_beam(fx):
+    prefix = os.path.join(fx.random_named_directory(), "beam")
+    beam_pattern = "MKAT-EA-L-JIM-2026"
+
+    primary_beam.runit(
+        _opts(
+            "to-fits",
+            beam_pattern=beam_pattern,
+            fits_format="ddfacet",
+            pixel_size="2arcmin",
+            npix=32,
+            start_freq="1300MHz",
+            chan_width="100MHz",
+            nchan=2,
+            output=prefix,
+        )
+    )
+
+    paths = _ddfacet_paths(prefix, ["xx", "xy", "yx", "yy"])
+    for path in paths.values():
+        assert os.path.exists(path)
+
+    # xy/yx: the cosine-taper model has no leakage.
+    for corr in ("xy", "yx"):
+        for ri in ("re", "im"):
+            assert np.all(fits.getdata(paths[(corr, ri)]) == 0.0)
+
+    # Independent axis/value check: invert the WCS of xx_re/xx_im at a few pixels and
+    # compare against CosineTaperBeam.voltages directly -- not the implementation's own
+    # reshape/transpose.
+    header = fits.getheader(paths[("xx", "re")])
+    assert header["CDELT1"] < 0  # beam_l_axis="-X" default
+    assert header["CDELT2"] > 0  # beam_m_axis="Y" default
+    wcs = WCS(header)
+    data_re = fits.getdata(paths[("xx", "re")])
+    data_im = fits.getdata(paths[("xx", "im")])
+    beam = CosineTaperBeam.from_builtin(beam_pattern)
+
+    for i_l, j_m, k_f in [(5, 20, 0), (16, 16, 1), (30, 2, 1)]:
+        l_axis_val, m_axis_val, freq_hz = wcs.wcs_pix2world([[i_l, j_m, k_f]], 0)[0]
+        l_deg, m_deg = -l_axis_val, m_axis_val  # sign_l=-1 (default "-X"), sign_m=+1 (default "Y")
+        expected = beam.voltages(np.array([l_deg]), np.array([m_deg]), np.array([freq_hz / 1e6]))[0, 0, 0]
+        got = data_re[k_f, j_m, i_l] + 1j * data_im[k_f, j_m, i_l]
+        assert got == pytest.approx(expected, abs=1e-6)
+
+
+def test_to_fits_ddfacet_axis_sign_flags(fx):
+    prefix = os.path.join(fx.random_named_directory(), "beam")
+    primary_beam.runit(
+        _opts(
+            "to-fits",
+            fits_format="ddfacet",
+            npix=16,
+            nchan=1,
+            output=prefix,
+            beam_l_axis="X",
+            beam_m_axis="-Y",
+        )
+    )
+    header = fits.getheader(f"{prefix}_xx_re.fits")
+    assert header["CDELT1"] > 0
+    assert header["CDELT2"] < 0
+
+
+def test_to_fits_ddfacet_circular_basis(fx):
+    prefix = os.path.join(fx.random_named_directory(), "beam")
+    beam_pattern = "MKAT-EA-L-JIM-2026"
+
+    primary_beam.runit(
+        _opts(
+            "to-fits",
+            beam_pattern=beam_pattern,
+            fits_format="ddfacet",
+            pol_basis="circular",
+            npix=16,
+            nchan=1,
+            start_freq="1400MHz",
+            output=prefix,
+        )
+    )
+
+    paths = _ddfacet_paths(prefix, ["rr", "rl", "lr", "ll"])
+    for path in paths.values():
+        assert os.path.exists(path)
+
+    header = fits.getheader(paths[("rr", "re")])
+    wcs = WCS(header)
+    beam = CosineTaperBeam.from_builtin(beam_pattern)
+    i_l, j_m, k_f = 10, 4, 0
+    l_axis_val, m_axis_val, freq_hz = wcs.wcs_pix2world([[i_l, j_m, k_f]], 0)[0]
+    l_deg, m_deg = -l_axis_val, m_axis_val
+    hh, vv = beam.voltages(np.array([l_deg]), np.array([m_deg]), np.array([freq_hz / 1e6]))[0, 0]
+
+    def _plane(corr):
+        re = fits.getdata(paths[(corr, "re")])[k_f, j_m, i_l]
+        im = fits.getdata(paths[(corr, "im")])[k_f, j_m, i_l]
+        return re + 1j * im
+
+    # corr_basis_transform is a single left-multiply E' = S @ diag(hh, vv) (see
+    # build_beam_grid_jones), not the baseline-coherency S @ B @ S^H form.
+    assert _plane("rr") == pytest.approx(hh / np.sqrt(2), abs=1e-6)
+    assert _plane("rl") == pytest.approx(1j * vv / np.sqrt(2), abs=1e-6)
+    assert _plane("lr") == pytest.approx(hh / np.sqrt(2), abs=1e-6)
+    assert _plane("ll") == pytest.approx(-1j * vv / np.sqrt(2), abs=1e-6)
+
+
+def test_to_fits_ddfacet_flags_ignored_warning_for_simms_format(fx, caplog):
+    out = fx.random_named_file(suffix=".fits")
+    with caplog.at_level(logging.WARNING):
+        primary_beam.runit(
+            _opts(
+                "to-fits",
+                fits_format="simms",
+                beam_l_axis="X",
+                npix=8,
+                nchan=1,
+                output=out,
+                log_level="WARNING",
+            )
+        )
+    assert any("only apply to --fits-format ddfacet" in r.message for r in caplog.records)
 
 
 def test_tag_ms_scalar_and_layout_and_map(fx):

--- a/tests/primary_beam_tests.py
+++ b/tests/primary_beam_tests.py
@@ -112,11 +112,11 @@ def test_to_fits_roundtrips_through_provider(fx):
     )
 
 
-def _ddfacet_paths(prefix, labels):
+def _cattery_paths(prefix, labels):
     return {(corr, ri): f"{prefix}_{corr}_{ri}.fits" for corr in labels for ri in ("re", "im")}
 
 
-def test_to_fits_ddfacet_writes_eight_files_and_matches_beam(fx):
+def test_to_fits_cattery_writes_eight_files_and_matches_beam(fx):
     prefix = os.path.join(fx.random_named_directory(), "beam")
     beam_pattern = "MKAT-EA-L-JIM-2026"
 
@@ -124,7 +124,7 @@ def test_to_fits_ddfacet_writes_eight_files_and_matches_beam(fx):
         _opts(
             "to-fits",
             beam_pattern=beam_pattern,
-            fits_format="ddfacet",
+            fits_format="cattery",
             pixel_size="2arcmin",
             npix=32,
             start_freq="1300MHz",
@@ -134,7 +134,7 @@ def test_to_fits_ddfacet_writes_eight_files_and_matches_beam(fx):
         )
     )
 
-    paths = _ddfacet_paths(prefix, ["xx", "xy", "yx", "yy"])
+    paths = _cattery_paths(prefix, ["xx", "xy", "yx", "yy"])
     for path in paths.values():
         assert os.path.exists(path)
 
@@ -162,12 +162,12 @@ def test_to_fits_ddfacet_writes_eight_files_and_matches_beam(fx):
         assert got == pytest.approx(expected, abs=1e-6)
 
 
-def test_to_fits_ddfacet_axis_sign_flags(fx):
+def test_to_fits_cattery_axis_sign_flags(fx):
     prefix = os.path.join(fx.random_named_directory(), "beam")
     primary_beam.runit(
         _opts(
             "to-fits",
-            fits_format="ddfacet",
+            fits_format="cattery",
             npix=16,
             nchan=1,
             output=prefix,
@@ -180,7 +180,7 @@ def test_to_fits_ddfacet_axis_sign_flags(fx):
     assert header["CDELT2"] < 0
 
 
-def test_to_fits_ddfacet_circular_basis(fx):
+def test_to_fits_cattery_circular_basis(fx):
     prefix = os.path.join(fx.random_named_directory(), "beam")
     beam_pattern = "MKAT-EA-L-JIM-2026"
 
@@ -188,7 +188,7 @@ def test_to_fits_ddfacet_circular_basis(fx):
         _opts(
             "to-fits",
             beam_pattern=beam_pattern,
-            fits_format="ddfacet",
+            fits_format="cattery",
             pol_basis="circular",
             npix=16,
             nchan=1,
@@ -197,7 +197,7 @@ def test_to_fits_ddfacet_circular_basis(fx):
         )
     )
 
-    paths = _ddfacet_paths(prefix, ["rr", "rl", "lr", "ll"])
+    paths = _cattery_paths(prefix, ["rr", "rl", "lr", "ll"])
     for path in paths.values():
         assert os.path.exists(path)
 
@@ -222,7 +222,7 @@ def test_to_fits_ddfacet_circular_basis(fx):
     assert _plane("ll") == pytest.approx(-1j * vv / np.sqrt(2), abs=1e-6)
 
 
-def test_to_fits_ddfacet_flags_ignored_warning_for_simms_format(fx, caplog):
+def test_to_fits_cattery_flags_ignored_warning_for_simms_format(fx, caplog):
     out = fx.random_named_file(suffix=".fits")
     with caplog.at_level(logging.WARNING):
         primary_beam.runit(
@@ -236,7 +236,7 @@ def test_to_fits_ddfacet_flags_ignored_warning_for_simms_format(fx, caplog):
                 log_level="WARNING",
             )
         )
-    assert any("only apply to --fits-format ddfacet" in r.message for r in caplog.records)
+    assert any("only apply to --fits-format cattery" in r.message for r in caplog.records)
 
 
 def test_tag_ms_scalar_and_layout_and_map(fx):


### PR DESCRIPTION
Apply code-review fixes to the Cattery/DDFacet beam-FITS handling added in this branch.

Changes:
- `FitsBeamProvider.from_cattery` now detects `$(reim)` / `$(realimag)` (and uppercase forms) as placeholders, so it no longer appends the default `_$(corr)_$(reim).fits` suffix when those tokens are present without a correlation placeholder.
- Missing Cattery beam files now raise a clear `FileNotFoundError` that includes both the resolved path and the original pattern.
- `load_cattery_beam_json` validates that the loaded JSON is a top-level object and raises a descriptive `ValueError` otherwise.
- Updated `skysim --primary-beam` help text to reflect that Cattery/DDFacet beams can be used with circular-correlation MSs when `--beam-jones full` is selected.
- Added regression tests for the placeholder detection, missing-file error, and non-object JSON rejection.

Tested:
- `ruff check` and `ruff format` pass.
- `tests/beam_tests.py`, `tests/primary_beam_tests.py`, `tests/predict_beam_e2e_tests.py`, `tests/predict_ascii_tests.py`, `tests/predict_fits_tests.py` all pass (183 passed, 2 skipped).
