### PR TITLE
primary_beam: declare `ms` alongside `output` in the pystep outputs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,4 +4,6 @@
 - Port cabs to shinobi/dosho
 - Fix `-pb` duplicate abbrevation. The `primary-beam` option retains it
   and `predict-backend` looses it
+- `primary-beam` declares `ms` alongside `output` in its pystep outputs, so
+  `tag-ms` (which mutates the MS in place) can be chained from in a recipe
 

--- a/src/simms/apps/primary_beam.py
+++ b/src/simms/apps/primary_beam.py
@@ -10,8 +10,12 @@ from simms import BIN, set_logger
 
 
 class PrimaryBeamOutputs(BaseModel):
-    """Passthrough output path of the primary-beam operation (beam FITS or beamed sky model)."""
+    """Passthrough paths of the primary-beam operation, so it can be wired into a
+    shinobi Recipe or dosho: `to-fits`/`apply`/`correct` write `output` (beam FITS
+    or beamed sky model), while `tag-ms` mutates `ms` in place and echoes it back --
+    the only handle a dependent step has to chain onto the tagged MS."""
 
+    ms: str | None = None
     output: str | None = None
 
 
@@ -156,4 +160,4 @@ def primary_beam(
 ) -> PrimaryBeamOutputs:
     opts = SimpleNamespace(**locals())
     runit(opts)
-    return PrimaryBeamOutputs(output=output)
+    return PrimaryBeamOutputs(ms=ms, output=output)

--- a/tests/primary_beam_tests.py
+++ b/tests/primary_beam_tests.py
@@ -259,6 +259,15 @@ def test_tag_ms_scalar_and_layout_and_map(fx):
     assert set(tnames) == {f"T{i}" for i in range(len(names))}
 
 
+def test_outputs_declare_both_passthrough_paths():
+    # `tag-ms` mutates the MS in place and produces no new file, so the
+    # echoed-back `ms` is the only handle a dependent step can chain onto;
+    # `output` covers to-fits/apply/correct. Dropping either makes that mode
+    # unwireable in a shinobi Recipe (or in dosho, which transcribes this
+    # model) -- invisible here, a build-time AttributeError downstream.
+    assert set(primary_beam.PrimaryBeamOutputs.model_fields) == {"ms", "output"}
+
+
 def _write_image(fx, npix=256, off=90):
     data = np.zeros((npix, npix), dtype=np.float32)
     data[npix // 2, npix // 2] = 3.0  # centre source


### PR DESCRIPTION
## What

`PrimaryBeamOutputs` gains an `ms` field, echoed back from the input, alongside the existing `output`.

## Why

`tag-ms` writes per-antenna telescope-name labels into the MS ANTENNA table **in place** and produces no new file. The echoed-back `ms` path is therefore the only handle a dependent step has to chain onto the tagged MS. Declaring only `output` leaves that mode unwireable — a recipe that tags an MS and then operates on it has no edge to express the ordering, and `recipe.outputs.<step>.ms` fails at build time with:

```
AttributeError: 'ms' is not an output of step 'telescope_name' (PrimaryBeamOutputs)
```

`skysim`/`telsim` already do this. `SimmsOutputs` is a passthrough `ms` for exactly this reason, and says so: *"Passthrough MS path, so telsim/skysim can be wired into a shinobi Recipe or dosho."* This restores the symmetry rather than inventing a convention.

## How it surfaced

dosho transcribes this outputs model field-for-field for its `simms-primary-beam` cab, and caracal2's `prep` worker tags the MS and then runs `manage_flags`/`clearcal` over it. Companion PR: shinobi-dosho/dosho#19 (dosho needs the field in its own copy regardless — its wrapper calls `runit(opts)` for side effects and returns its own model, so that copy is what shinobi builds the DAG from).

## Test plan

- New `test_outputs_declare_both_passthrough_paths` pins both passthroughs — the regression is invisible in-repo (nothing here consumes the model) but a build-time error downstream
- `uv run --group tests python -m pytest tests/primary_beam_tests.py` — 12 passed
- `uv run --group ruff ruff check src tests` — clean
- CHANGES.md noted under 3.0.0 -> 3.0.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)