### PR TITLE
fits_skies: don't reject a cube written on the MS's own frequency grid

### DIFF
--- a/src/simms/skymodel/fits_skies.py
+++ b/src/simms/skymodel/fits_skies.py
@@ -647,7 +647,15 @@ def prepare_fits_sky(
 
     fits_freqs, fits_delta_nu = _fits_frequencies(fds)
     nchan_fits = fits_freqs.size
-    fits_range = (fits_freqs[0] - 0.5 * fits_delta_nu, fits_freqs[-1] + 0.5 * fits_delta_nu)
+    # Widen by a millionth of a channel before the containment test. The most natural
+    # case -- a cube written on the MS's own frequency grid -- has the two band edges
+    # equal in exact arithmetic but differing in the last ulp, because the MS width
+    # comes from CHAN_WIDTH and the FITS width from CDELT3. Without this, such a cube
+    # is rejected over a discrepancy of ~1e-7 Hz at 1.4 GHz, with an error message
+    # that prints the two ranges identically. A genuine mismatch is off by a
+    # meaningful fraction of a channel, far above this.
+    edge_tol = 1e-6 * abs(fits_delta_nu)
+    fits_range = (fits_freqs[0] - 0.5 * fits_delta_nu - edge_tol, fits_freqs[-1] + 0.5 * fits_delta_nu + edge_tol)
     ms_range = (ms_start_freq, ms_end_freq)
     if nchan_fits > 1 and not is_range_in_range(ms_range, fits_range):
         raise FITSSkymodelError(

--- a/tests/predict_fits_tests.py
+++ b/tests/predict_fits_tests.py
@@ -263,6 +263,27 @@ def test_ms_band_outside_fits_band_raises(params, uvw):
         prepare_fits_sky(path, RA0, DEC0, np.array([2.0e9, 2.1e9]), 1e6, 2, nrow=uvw.shape[0])
 
 
+def test_exactly_matching_band_is_accepted(params, uvw):
+    """A cube on the MS's own frequency grid must not be rejected by float noise.
+
+    The MS channel width comes from CHAN_WIDTH and the FITS one from CDELT3, so
+    the two band edges agree in exact arithmetic but can differ in the last ulp.
+    Before the edge tolerance this raised over ~1e-7 Hz at 1.4 GHz, with an error
+    that printed both ranges identically.
+    """
+    npix, nchan = 32, 64
+    f0, f1 = 1.4180e9, 1.4220e9
+    fits_freqs = np.linspace(f0, f1, nchan)
+    header = make_header(npix, nchan=nchan, freqs=fits_freqs)
+    path = write_image(params, np.zeros((nchan, npix, npix)), header)
+    # Computed a different (but mathematically equal) way than CDELT3, as a caller
+    # reading CHAN_WIDTH from an MS would.
+    ms_delta_nu = (f1 - f0) / (nchan - 1)
+    assert ms_delta_nu != fits_freqs[1] - fits_freqs[0]  # the ulp difference is real
+    prepared = prepare_fits_sky(path, RA0, DEC0, fits_freqs, ms_delta_nu, 2, nrow=uvw.shape[0])
+    assert prepared.chan_freqs.size == nchan
+
+
 # --------------------------------------------------------------------------- geometry
 
 


### PR DESCRIPTION
The band-containment check compared MS edges (from CHAN_WIDTH) against FITS edges (from CDELT3). Those are equal in exact arithmetic when the cube is written on the MS grid -- the most natural case -- but differ in the last ulp, so prepare_fits_sky raised FITSSkymodelError over a discrepancy of ~2.4e-7 Hz at 1.42 GHz, with a message that printed the two ranges identically.

Widen the FITS range by a millionth of a channel before the test. A genuine mismatch is off by a meaningful fraction of a channel, orders of magnitude above this.

Found while benchmarking a narrowband line cube on kudu, which could not be constructed at all without tripping it.

<!-- Thanks for contributing! Please keep PRs small and focused. -->

## Summary

<!-- What does this change do, and why? -->

## Related issue

<!-- e.g. "Closes #12". Delete if not applicable. -->

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / internal
- [ ] Other:

## Checklist

- [x] `uv run --group tests python -m pytest` passes locally
- [x] `uv run --group ruff ruff check src tests` is clean
- [] Docs updated if public API changed (`uv run sphinx-build -b html docs docs/_build/html`)
- [x] Added/updated tests for the change (named `*_tests.py`)
